### PR TITLE
Fix Illegal Seek error when reading from pipe

### DIFF
--- a/zfec/cmdline_zfec.py
+++ b/zfec/cmdline_zfec.py
@@ -35,10 +35,12 @@ def main():
     parser.add_argument('-V', '--version', help='print out version number and exit', action='store_true')
     args = parser.parse_args()
 
+    is_infile_stdin = False
     if args.prefix is None:
         args.prefix = args.inputfile.name
         if args.prefix == "<stdin>":
             args.prefix = ""
+            is_infile_stdin = True
 
     if args.verbose and args.quiet:
         print "Please choose only one of --verbose and --quiet."
@@ -57,10 +59,23 @@ def main():
         if args.requiredshares == args.totalshares:
             print "warning: silly parameters: requiredshares == totalshares, which means that all shares will be required in order to reconstruct the file.  You could use \"split\" for the same effect.  But proceeding to do it anyway..."
 
-    args.inputfile.seek(0, 2)
-    fsize = args.inputfile.tell()
-    args.inputfile.seek(0, 0)
-    return filefec.encode_to_files(args.inputfile, fsize, args.output_dir, args.prefix, args.requiredshares, args.totalshares, args.suffix, args.force, args.verbose)
+    in_file = args.inputfile
+    try:
+        args.inputfile.seek(0, 2)
+        fsize = args.inputfile.tell()
+        args.inputfile.seek(0, 0)
+    except IOError:
+        if is_infile_stdin:
+            contents = args.inputfile.read()
+            fsize = len(contents)
+        else:
+            raise Exception("zfec - needs a real (Seekable) file handle to"
+                            " measure file size upfront.")
+
+    return filefec.encode_to_files(in_file, fsize, args.output_dir,
+                                   args.prefix, args.requiredshares,
+                                   args.totalshares, args.suffix,
+                                   args.force, args.verbose)
 
 # zfec -- fast forward error correction library with Python interface
 #

--- a/zfec/test/test_zfec.py
+++ b/zfec/test/test_zfec.py
@@ -361,5 +361,28 @@ class Cmdline(unittest.TestCase):
                            os.path.join(self.tempdir.name,
                                         'test.data-recovered'))
 
+    def test_stdin(self, noisy=VERBOSE):
+        sys.stdin = open(os.path.join(self.tempdir.name, "test.data"))
+        sys.argv = ["zfec", "-"]
+        retcode = zfec.cmdline_zfec.main()
+
+        RE=re.compile(zfec.filefec.RE_FORMAT % ('test.data', ".fec",))
+        fns = os.listdir(self.tempdir.name)
+        assert len(fns) >= self.DEFAULT_M, (fns, self.DEFAULT_M, self.tempdir, self.tempdir.name,)
+        sharefns = [ os.path.join(self.tempdir.name, fn) for fn in fns if self.RE.match(fn) ]
+        random.shuffle(sharefns)
+        del sharefns[self.DEFAULT_K:]
+
+        sys.argv = ["zunfec",]
+        sys.argv.extend(sharefns)
+        sys.argv.extend(['-o', os.path.join(self.tempdir.name, 'test.data-recovered'),])
+
+        retcode = zfec.cmdline_zunfec.main()
+        assert retcode == 0, retcode
+        import filecmp
+        assert filecmp.cmp(os.path.join(self.tempdir.name, 'test.data'),
+                           os.path.join(self.tempdir.name,
+                                        'test.data-recovered'))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
zfec command line script now handles piping the input to it in below format.

`cat some-file | zfec -`

This pull request does following
* Handle when input is piped into stdin (Illegal seek error)
* Adds a basic test to check this (though we can't cleanly mock sys.stdin)
* Add setUp and tearDown functions to avoid code duplication in `Cmdline` test class.

Fix #3 

cc: @warner  @vu3rdd 