### PR TITLE
fec.c: switch back to old C syntax to appease windows compiler

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 install:
   - |
-    %PYTHON%\python.exe -m pip install wheel tox
+    %PYTHON%\python.exe -m pip install -U wheel tox setuptools
 
 # note:
 # %PYTHON% has: python.exe

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,5 @@ deps = pyutil
 usedevelop = True
 
 commands =
+         pip list
 	 python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,4 @@ deps = pyutil
 usedevelop = True
 
 commands =
-         pip list
 	 python setup.py test

--- a/zfec/_fecmodule.c
+++ b/zfec/_fecmodule.c
@@ -632,6 +632,10 @@ static PyMethodDef fec_functions[] = {
     {NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = { PyModuleDef_HEAD_INIT, "_fec", fec__doc__, -1, fec_functions, };
+#endif
+
 #ifndef PyMODINIT_FUNC	/* declarations for DLL import/export */
 #define PyMODINIT_FUNC void
 #endif
@@ -652,7 +656,6 @@ init_fec(void) {
         return MOD_ERROR_VAL;
 
 #if PY_MAJOR_VERSION >= 3
-    static struct PyModuleDef moduledef = { PyModuleDef_HEAD_INIT, "_fec", fec__doc__, -1, fec_functions, };
     module = PyModule_Create(&moduledef);
 #else
     module = Py_InitModule3("_fec", fec_functions, fec__doc__);

--- a/zfec/_fecmodule.c
+++ b/zfec/_fecmodule.c
@@ -125,6 +125,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
     PyObject** fast_desired_blocks_nums_items;
     size_t * c_desired_blocks_nums = (size_t*)alloca(self->mm * sizeof(size_t));
     unsigned* c_desired_checkblocks_ids = (unsigned*)alloca((self->mm - self->kk) * sizeof(unsigned));
+    size_t i;
     PyObject* fastinblocks = NULL;
     PyObject** fastinblocksitems;
     Py_ssize_t sz, oldsz = 0;
@@ -133,7 +134,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "O|O:Encoder.encode", &inblocks, &desired_blocks_nums))
         return NULL;
 
-    for (size_t i = 0; i < self->mm - self->kk; i++)
+    for (i = 0; i < self->mm - self->kk; i++)
         pystrs_produced[i] = NULL;
 
     if (desired_blocks_nums) {
@@ -145,7 +146,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
         num_desired_blocks = PySequence_Fast_GET_SIZE(fast_desired_blocks_nums);
         fast_desired_blocks_nums_items = PySequence_Fast_ITEMS(fast_desired_blocks_nums);
 
-        for (size_t i = 0; i < num_desired_blocks; i++) {
+        for (i = 0; i < num_desired_blocks; i++) {
             if (!PyInt_Check(fast_desired_blocks_nums_items[i])) {
                 PyErr_Format(py_fec_error, "Precondition violation: second argument is required to contain int.");
                 goto err;
@@ -156,7 +157,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
         }
     } else {
         num_desired_blocks = self->mm;
-        for (size_t i = 0; i<num_desired_blocks; i++)
+        for (i = 0; i<num_desired_blocks; i++)
             c_desired_blocks_nums[i] = i;
         num_check_blocks_produced = self->mm - self->kk;
     }
@@ -175,7 +176,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
     if (!fastinblocksitems)
         goto err;
 
-    for (size_t i = 0; i < self->kk; i++) {
+    for (i = 0; i < self->kk; i++) {
         if (!PyObject_CheckReadBuffer(fastinblocksitems[i])) {
             PyErr_Format(py_fec_error, "Precondition violation: %zu'th item is required to offer the single-segment read character buffer protocol, but it does not.", i);
             goto err;
@@ -191,7 +192,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
 
     /* Allocate space for all of the check blocks. */
 
-    for (size_t i = 0; i < num_desired_blocks; i++) {
+    for (i = 0; i < num_desired_blocks; i++) {
         if (c_desired_blocks_nums[i] >= self->kk) {
             c_desired_checkblocks_ids[check_block_index] = c_desired_blocks_nums[i];
             pystrs_produced[check_block_index] = PyString_FromStringAndSize(NULL, sz);
@@ -213,7 +214,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
     if (result == NULL)
         goto err;
     check_block_index = 0;
-    for (size_t i = 0; i < num_desired_blocks; i++) {
+    for (i = 0; i < num_desired_blocks; i++) {
         if (c_desired_blocks_nums[i] < self->kk) {
             Py_INCREF(fastinblocksitems[c_desired_blocks_nums[i]]);
             if (PyList_SetItem(result, i, fastinblocksitems[c_desired_blocks_nums[i]]) == -1) {
@@ -230,7 +231,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
 
     goto cleanup;
   err:
-    for (size_t i = 0; i < num_check_blocks_produced; i++)
+    for (i = 0; i < num_check_blocks_produced; i++)
         Py_XDECREF(pystrs_produced[i]);
     Py_XDECREF(result); result = NULL;
   cleanup:

--- a/zfec/fec.c
+++ b/zfec/fec.c
@@ -233,6 +233,7 @@ _invert_mat(gf* src, size_t k) {
     gf c;
     size_t irow = 0;
     size_t icol = 0;
+    size_t row, col, i, ix;
 
     unsigned* indxc = (unsigned*) malloc (k * sizeof(unsigned));
     unsigned* indxr = (unsigned*) malloc (k * sizeof(unsigned));
@@ -243,10 +244,10 @@ _invert_mat(gf* src, size_t k) {
     /*
      * ipiv marks elements already used as pivots.
      */
-    for (size_t i = 0; i < k; i++)
+    for (i = 0; i < k; i++)
         ipiv[i] = 0;
 
-    for (size_t col = 0; col < k; col++) {
+    for (col = 0; col < k; col++) {
         gf *pivot_row;
         /*
          * Zeroing column 'col', look for a non-zero element.
@@ -257,9 +258,9 @@ _invert_mat(gf* src, size_t k) {
             icol = col;
             goto found_piv;
         }
-        for (size_t row = 0; row < k; row++) {
+        for (row = 0; row < k; row++) {
             if (ipiv[row] != 1) {
-                for (size_t ix = 0; ix < k; ix++) {
+                for (ix = 0; ix < k; ix++) {
                     if (ipiv[ix] == 0) {
                         if (src[row * k + ix] != 0) {
                             irow = row;
@@ -279,7 +280,7 @@ _invert_mat(gf* src, size_t k) {
          * optimizing.
          */
         if (irow != icol)
-            for (size_t ix = 0; ix < k; ix++)
+            for (ix = 0; ix < k; ix++)
                 SWAP (src[irow * k + ix], src[icol * k + ix], gf);
         indxr[col] = irow;
         indxc[col] = icol;
@@ -293,7 +294,7 @@ _invert_mat(gf* src, size_t k) {
              */
             c = inverse[c];
             pivot_row[icol] = 1;
-            for (size_t ix = 0; ix < k; ix++)
+            for (ix = 0; ix < k; ix++)
                 pivot_row[ix] = gf_mul (c, pivot_row[ix]);
         }
         /*
@@ -306,7 +307,7 @@ _invert_mat(gf* src, size_t k) {
         id_row[icol] = 1;
         if (memcmp (pivot_row, id_row, k * sizeof (gf)) != 0) {
             gf *p = src;
-            for (size_t ix = 0; ix < k; ix++, p += k) {
+            for (ix = 0; ix < k; ix++, p += k) {
                 if (ix != icol) {
                     c = p[icol];
                     p[icol] = 0;
@@ -316,9 +317,9 @@ _invert_mat(gf* src, size_t k) {
         }
         id_row[icol] = 0;
     }                           /* done all columns */
-    for (size_t col = k; col > 0; col--)
+    for (col = k; col > 0; col--)
         if (indxr[col-1] != indxc[col-1])
-            for (size_t row = 0; row < k; row++)
+            for (row = 0; row < k; row++)
                 SWAP (src[row * k + indxr[col-1]], src[row * k + indxc[col-1]], gf);
     free(indxc);
     free(indxr);


### PR DESCRIPTION
The for-loop inline typedef was causing the appveyor C compiler to complain
about a syntax error. That compiler was also ignoring the -std=c99 argument,
which suggests it's pretty old. It might be a self-inflicted problem; our
misc/windows-build.cmd script might be pinning a specific compiler, which
could be old. Most of this windows tooling is cargo-culted from other
projects, so if anyone knows the Right Way To Do It, please please file a PR.