### PR TITLE
move "name" from setup.cfg to setup.py, to help old setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [metadata]
-name = zfec
 summary = efficient, portable erasure coding tool
 description-file =
   README.rst

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,14 @@ extensions = [
     )
 ]
 
+# Most of our metadata lives in setup.cfg [metadata]. We put "name" here
+# because the setuptools-22.0.5 on slackware can't find it there, which breaks
+# packaging. We put "version" here so that Versioneer works correctly, and
+# "install_requires" because I don't know how to express the python_version
+# clause within the setup.cfg syntax.
+
 setup(
+    name="zfec",
     version=versioneer.get_version(),
     install_requires=[
         "pyutil >= 3.0.0",


### PR DESCRIPTION
This should fix packaging on slackware, which has setuptools-22.0.5, which
apparently doesn't know how to find "name" in setup.cfg's metadata section.