### PR TITLE
Remove non-ascii character from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-﻿
+
 
 zfec -- efficient, portable erasure coding tool
 ===============================================


### PR DESCRIPTION
This was causing build failure on Debian with following error

```
I: pybuild base:217: python3.6 setup.py clean
Traceback (most recent call last):
  File "setup.py", line 60, in <module>
    long_description=open('README.rst', 'rU').read(),
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 0: ordinal
not in range(128)
```