### PR TITLE
Create wheel packages using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 # Build sdist+wheel packages using GitHub Actions.  Mostly adopted
 # from https://cibuildwheel.readthedocs.io/en/stable/setup/
 
-name: Build
+name: Build Python packages
 
 on: [push, pull_request]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: [push, pull_request]
 
+env:
+  CIBW_TEST_REQUIRES: tox
+  CIBW_TEST_COMMAND: "tox -e py"
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,21 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,6 @@ jobs:
         run: |
           choco install vcpython27 -f -y
 
-      - name: Install Python packages
-        run: |
-          pip install -U pip tox virtualenv
-
-      - name: Run tests
-        run: |
-          tox -e py
-
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   CIBW_TEST_REQUIRES: tox
-  CIBW_TEST_COMMAND: "tox -e py"
+  CIBW_TEST_COMMAND: "tox -e py -c {project}/tox.ini"
 
 jobs:
   build_wheels:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==1.6.0
+
+      - name: Install Visual C++ for Python 2.7
+        if: runner.os == 'Windows'
+        run: |
+          choco install vcpython27 -f -y
+
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,14 @@ jobs:
         run: |
           choco install vcpython27 -f -y
 
+      - name: Install Python packages
+        run: |
+          pip install -U pip tox virtualenv
+
+      - name: Run tests
+        run: |
+          tox -e py
+
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# Build sdist+wheel packages using GitHub Actions.  Mostly adopted
+# from https://cibuildwheel.readthedocs.io/en/stable/setup/
+
 name: Build
 
 on: [push, pull_request]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 env:
   CIBW_TEST_REQUIRES: tox
   CIBW_TEST_COMMAND: "tox -e py -c {project}/tox.ini"
+  # Twisted isn't quite ready on Windows Python 3.9
+  CIBW_SKIP: cp39-win*
 
 jobs:
   build_wheels:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        name: Check out zfec sources
 
       - uses: actions/setup-python@v2
         name: Install Python
@@ -41,14 +42,17 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v2
+        name: Upload artifacts
         with:
           path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
+        name: Check out zfec sources
 
       - uses: actions/setup-python@v2
         name: Install Python
@@ -59,5 +63,6 @@ jobs:
         run: python setup.py sdist
 
       - uses: actions/upload-artifact@v2
+        name: Upload artifacts
         with:
           path: dist/*.tar.gz


### PR DESCRIPTION
This PR contains GitHub Actions configuration that will create wheel (for macOS, Windows, and Linux) and source packages of zfec, using [cibuildwheel](https://pypi.org/project/cibuildwheel/).  The configuration is pretty much straight from cibuildwheel [documentation](https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions).  Examples of this in action are [here](https://github.com/sajith/zfec/actions).

This will also run `tox -e py` where it makes sense: currently skipping running `tox` on Windows with Python 3.9, because twisted isn't happy about being in that environment.

In order to test these packages, I published [packages on testpypi](https://test.pypi.org/project/zfec/1.5.4/), and made a [draft PR](https://github.com/tahoe-lafs/tahoe-lafs/pull/804) on Tahoe-LAFS that uses zfec package from testpypi -- it successfully runs Tahoe-LAFS tests on Windows using GitHub Actions, without having to install a compiler.

Note that packages on testpypi are tagged 1.5.4.  That is because I wanted to ensure that tagging creates packages as expected.   I'm proposing some steps to release a 1.5.4 for real:

- Update changelong and NEWS.
- Maybe add Python 3.8 to the list of languages in `setup.cfg`.
- Tag `zfec-1.5.4` in this repository.
- Upload whl/sdist packages generated by GA to pypi.

And then, outside of this repository:

- Remove vcpython27 installation step from Tahoe-LAFS and Magic-Folder Windows CI.

We could also possibly automate the part where packages are published on pypi, but that probably won't be necessary now since zfec is not a super active project.

(I think macOS and Linux will continue to need a compiler because [pyyaml](https://pypi.org/project/PyYAML/#files) has published .whl packages only for Windows; I am not quite sure about PyOpenSSL's story.)