### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
+  - "3.9-dev"
 install: pip install -U pip tox virtualenv
 script: tox -e py
 notifications:


### PR DESCRIPTION
Changes:

* Test zfec against Python 3.7, 3.8, and 3.9-dev.
* Travis CI has [deprecated](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast) `sudo` key; remove it.
