### PR TITLE
Attempt to upgrade AppVeyor's really old pip

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ test_script:
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
   - |
-    misc\windows-build.cmd %PYTHON%\Scripts\tox.exe -e py
+    misc\windows-build.cmd %PYTHON%\python.exe -m tox -e py
 
 after_test:
   # This step builds your wheels.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,8 @@ environment:
 
 install:
   - |
-    %PYTHON%\python.exe -m pip install -U wheel tox setuptools
+    %PYTHON%\python.exe -m pip install -U wheel tox setuptools pip
+    %PYTHON%\python.exe -m pip --version
 
 # note:
 # %PYTHON% has: python.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 install:
   - |
-    %PYTHON%\python.exe -m pip install -U wheel tox setuptools
+    %PYTHON%\python.exe -m pip install -U wheel tox setuptools pip
 
 # note:
 # %PYTHON% has: python.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,8 +15,7 @@ environment:
 
 install:
   - |
-    %PYTHON%\python.exe -m pip install -U wheel tox setuptools pip
-    %PYTHON%\python.exe -m pip --version
+    %PYTHON%\python.exe -m pip install -U wheel tox setuptools
 
 # note:
 # %PYTHON% has: python.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ test_script:
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python evrsion you want to use on PATH.
   - |
-    misc\windows-build.cmd %PYTHON%\python.exe -m tox -e py
+    misc\windows-build.cmd tox -e py
 
 after_test:
   # This step builds your wheels.

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,6 @@ deps = .[test]
 usedevelop = True
 
 commands =
-	 python setup.py test
+     python -m pip install --upgrade pip
+     python -m pip --version
+     python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,12 @@ envlist = py27,py35,py36
 skip_missing_interpreters = True
 
 [testenv]
-deps = .[test]
+deps =
+     .[test]
+     pip >= 20.2.3
+
 usedevelop = True
 
 commands =
-     python -m pip install --upgrade pip
      python -m pip --version
      python setup.py test


### PR DESCRIPTION
Python 3.4 tests have been [failing](https://ci.appveyor.com/project/tahoe-lafs/zfec/builds/35192258) on AppVeyor, presumably because of the really old pip version:

```
misc\windows-build.cmd %PYTHON%\Scripts\tox.exe -e py
Using default MSVC build environment
py create: C:\projects\zfec\.tox\py
py installdeps: .[test]
ERROR: invocation failed (exit code 2), logfile: C:\projects\zfec\.tox\py\log\py-1.log
================================== log start ==================================
Processing c:\projects\zfec
Exception:
Traceback (most recent call last):
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2610, in _dep_map
    return self.__dep_map
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2685, in __getattr__
    raise AttributeError(attr)
AttributeError: _Distribution__dep_map
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\basecommand.py", line 209, in main
    status = self.run(options, args)
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\commands\install.py", line 310, in run
    wb.build(autobuilding=True)
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\wheel.py", line 748, in build
    self.requirement_set.prepare_files(self.finder)
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\req\req_set.py", line 360, in prepare_files
    ignore_dependencies=self.ignore_dependencies))
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\req\req_set.py", line 647, in _prepare_file
    set(req_to_install.extras) - set(dist.extras)
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2810, in extras
    return [dep for dep in self._dep_map if dep]
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2624, in _dep_map
    dm.setdefault(extra,[]).extend(parse_requirements(reqs))
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2980, in parse_requirements
    "version spec")
  File "C:\projects\zfec\.tox\py\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2956, in scan_list
    raise RequirementParseError(msg, line, "at", line[p:])
pip._vendor.pkg_resources.RequirementParseError: Expected ',' or end-of-list in argparse >= 0.8 ; python_version <= '2.7' at  ; python_version <= '2.7'
You are using pip version 8.1.1, however version 20.2.3 is available.
You should consider upgrading via the 'python -m pip install --upgrade pip' command.
=================================== log end ===================================
ERROR: could not install deps [.[test]]; v = InvocationError("'C:\\projects\\zfec\\.tox\\py\\Scripts\\python.EXE' -m pip install '.[test]'", 2)
___________________________________ summary ___________________________________
ERROR:   py: could not install deps [.[test]]; v = InvocationError("'C:\\projects\\zfec\\.tox\\py\\Scripts\\python.EXE' -m pip install '.[test]'", 2)
Command exited with code 1
```