### PR TITLE
Remove deprecated 'U' flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     name="zfec",
     version=versioneer.get_version(),
     description="An efficient, portable erasure coding tool",
-    long_description=open('README.rst', 'rU').read(),
+    long_description=open('README.rst', 'r').read(),
     url="https://github.com/tahoe-lafs/zfec",
     install_requires=[
         "argparse >= 0.8 ; python_version <= '2.7'",


### PR DESCRIPTION
Python 3.7+ gives [this](https://travis-ci.org/github/tahoe-lafs/zfec/jobs/727020999#L209) warning:

```
  py run-test: commands[1] | python setup.py test
  setup.py:60: DeprecationWarning: 'U' mode is deprecated
    long_description=open('README.rst', 'rU').read(),
```