### PR TITLE
Remove "python_version <= 2.7" install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,8 @@ setup(
     long_description=open('README.rst', 'rU').read(),
     url="https://github.com/tahoe-lafs/zfec",
     install_requires=[
-        "argparse >= 0.8 ; python_version <= '2.7'",
-        # note to self: single-quotes on the '2.7' are ok:
-        # https://github.com/pypa/packaging/blob/16.8/packaging/markers.py#L121
-],
+        "argparse >= 0.8",
+    ],
     extras_require={
         "bench": ["pyutil >= 3.0.0"],
         "test": ["twisted", "setuptools_trial", "pyutil >= 3.0.0"],


### PR DESCRIPTION
I'm pretty sure `python_version <= '2.7'"` is meaningless here, certainly at this time, because zfec builds just fine with Python 2.7 and and a bunch of Python 3+ versions.  This was added in 45e5dab579, probably by mistake.