### PR TITLE
Add Python 3.8 to languages list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifier =
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
   Topic :: Utilities
   Topic :: System :: Systems Administration
   Topic :: System :: Filesystems


### PR DESCRIPTION
Turns out that:

* [Tests pass just fine](https://travis-ci.org/github/tahoe-lafs/zfec/builds/727021104) with Python 3.8;
* [Packages are built](https://github.com/tahoe-lafs/zfec/actions/runs/253846656) just fine with Python 3.8; and
* those packages are [published](https://test.pypi.org/project/zfec/1.5.4/#files) on testpypi, just with this missing metadata.

Might as well add Python 3.8 to the list of languages in `setup.cfg`.