### PR TITLE
Omit building wheels for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,10 @@
 
 name: Build Python packages
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
 
 env:
   CIBW_TEST_REQUIRES: tox


### PR DESCRIPTION
Building wheels across all three OSes and several Python and PyPy versions takes a rather long time, and it is not probably necessary.

PR #27 will add a GitHub Actions workflow that will run tests across all three OSes and the same Python and PyPy versions, and that finishes quicker.  That should be a sufficient check for pull requests, besides the tests currently running on Travis CI and AppVeyor.