### PR TITLE
Prepare a 1.5.4 release 

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,12 @@
 User visible changes in zfec.           -*- outline -*-
 
+* Release 1.5.4 (2020-09-17)
+
+** Upload wheel packages to the Python Package Index.
+   Wheel packages are now built for Python 2.7, 3.5, 3.7, 3.8, PyPy2,
+   and PyPy3, for macOS, GNU/Linux, and Windows platforms, using
+   cibuildwheel on GitHub Actions.  No changes to zfec itself.
+
 * Release 1.5.3 (2018-04-07)
 
 ** Fix setup.py problem that broke builds on slackware (or other systems with

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+Thu Sep 17 10:20:40 EST 2020 sajith@hcoop.net
+  tagged zfec-1.5.4
+
 Thu Dec 20 13:55:55 MST 2007  zooko@zooko.com
   * zfec: silence a warning when compiling on Mac OS X with gcc, and refactor a complicated #define stanza into the shared header file
 
@@ -6,7 +9,7 @@ Thu Dec 20 13:55:32 MST 2007  zooko@zooko.com
 
 Thu Dec 20 09:33:55 MST 2007  zooko@zooko.com
   tagged zfec-1.3.1
-	
+
 Thu Dec 20 09:31:13 MST 2007  zooko@zooko.com
   * zfec: dual-license under GPL and TGPPL
 
@@ -21,15 +24,15 @@ Thu Dec 20 09:23:41 MST 2007  zooko@zooko.com
 
 Wed Nov 14 09:44:26 MST 2007  zooko@zooko.com
   * zfec: set STRIDE to 8192 after extensive experimentation on my PowerPC G4 867 MHz (256 KB L2 cache)
-  
+
 
 Mon Nov 12 07:58:19 MST 2007  zooko@zooko.com
   * zfec: reorder the inner loop to be more cache-friendly
-  
+
   Loop over this stride of each input block before looping over all strides of
   this input block.  In theory, this should allow the strides of the input blocks
   to remain in cache while we produce all of the output blocks.
-  
+
 
 Sun Nov 11 10:04:44 MST 2007  zooko@zooko.com
   * zfec: do encoding within a fixed window of memory in order to be cache friendly


### PR DESCRIPTION
This updates the changelog and NEWS files.  No other changes to zfec itself, as the release is for shipping wheel packages.