### PR TITLE
Test .whl packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ on:
     #   - zfec-*
 
 env:
-  CIBW_TEST_REQUIRES: tox
-  CIBW_TEST_COMMAND: "tox -e py -c {project}/tox.ini"
+  # CIBW_TEST_REQUIRES: tox
+  CIBW_TEST_COMMAND: python -c 'import zfec; print("zfec version {}".format(zfec.__version__))'
   # Twisted isn't quite ready on Windows Python 3.9
   CIBW_SKIP: cp39-win*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ name: Build Python packages
 
 on:
   push:
-    tags:
-      - zfec-*
+    # tags:
+    #   - zfec-*
 
 env:
   CIBW_TEST_REQUIRES: tox


### PR DESCRIPTION
Trying out a fix for #34: test that the .whl packages actually work.  Running tox only tests zefc itself, and not the package.