### PR TITLE
Test that zfec package can be used by Python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
       - zfec-*
 
 env:
-  CIBW_TEST_REQUIRES: tox
   CIBW_TEST_COMMAND: "python -c 'import zfec'"
   # Twisted isn't quite ready on Windows Python 3.9
   CIBW_SKIP: cp39-win*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.0
+          python -m pip install cibuildwheel==1.6.4
 
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CIBW_TEST_REQUIRES: tox
-  CIBW_TEST_COMMAND: python -c 'import zfec; print("zfec version {}".format(zfec.__version__))'
+  CIBW_TEST_COMMAND: "python -c 'import zfec; print(zfec.__version__)'"
   # Twisted isn't quite ready on Windows Python 3.9
   CIBW_SKIP: cp39-win*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CIBW_TEST_REQUIRES: tox
-  CIBW_TEST_COMMAND: "tox -e py -c {project}/tox.ini"
+  CIBW_TEST_COMMAND: python -c 'import zfec; print("zfec version {}".format(zfec.__version__))'
   # Twisted isn't quite ready on Windows Python 3.9
   CIBW_SKIP: cp39-win*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CIBW_TEST_REQUIRES: tox
-  CIBW_TEST_COMMAND: "python -c 'import zfec; print(zfec.__version__)'"
+  CIBW_TEST_COMMAND: "python -c 'import zfec'"
   # Twisted isn't quite ready on Windows Python 3.9
   CIBW_SKIP: cp39-win*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ on:
       - zfec-*
 
 env:
-  CIBW_TEST_COMMAND: "python -c 'import zfec'"
+  CIBW_TEST_COMMAND: python -c "import zfec; print(zfec.__version__)"
+
   # Twisted isn't quite ready on Windows Python 3.9
   CIBW_SKIP: cp39-win*
 


### PR DESCRIPTION
Trying out a fix for #34: test that the `.whl` packages that were just generated actually work. Running tox only tests zefc itself, and not packaging.