### PR TITLE
Build working Windows .whl packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ on:
 
 env:
   CIBW_TEST_REQUIRES: tox
-  CIBW_TEST_COMMAND: "tox -e py -c {project}/tox.ini"
+  # Just make sure that Python can use zfec package
+  CIBW_TEST_COMMAND: python -c "import zfec; print(zfec.__version__)"
+
   # Twisted isn't quite ready on Windows Python 3.9
   CIBW_SKIP: cp39-win*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.0
+          python -m pip install cibuildwheel==1.6.4
 
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ on:
     types: [published, created, edited]
 
 env:
-  CIBW_TEST_REQUIRES: tox
   # Just make sure that Python can use zfec package
   CIBW_TEST_COMMAND: python -c "import zfec; print(zfec.__version__)"
 


### PR DESCRIPTION
This PR is a fix for #34. Changes:

* Do not run the test suite.
* Instead of running the test suite, try to use zfec library.  This is a more useful packaging test.
* Update to the current version of cibuildwheels.