### PR TITLE
Drop failing pypy3 tests, and other CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
           - 3.7
           - 3.8
           - pypy2
-          - pypy3
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
           - windows-latest
         python-version:
           - 2.7
-          - 3.5
           - 3.6
           - 3.7
           - 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py36
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py36,py37,py38,pypy2,pypy3
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Changes:

* Testing zfec with pypy3 on Windows has been failing, as reported in #38.  Disabling pypy3 testing on Windows alone does not appear to be straightforward with GitHub Actions.  This PR drops pypy3 from the test matrix, until a time when things get better.
* This PR drops Python 3.5 from the test matrix, because py35 has been EOL-ed.
* Adds newer Python3 versions and pypy to tox envlist, and drops Python 3.5 from it.