### PR TITLE
Test with Python 3.9, except on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,13 @@ jobs:
           - 3.8
           - pypy2
 
+        # Twisted is not ready for Python 3.9 on Windows.
+        include:
+          - os: ubuntu-latest
+            python-version: 3.9
+          - os: macos-latest
+            python-version: 3.9
+
     steps:
 
       # Get vcpython27 on Windows + Python 2.7, to build zfec.  See


### PR DESCRIPTION
A partial fix for #44: this PR enables testing zfec against Python 3.9 on macOS and Linux.