### PR TITLE
Fix Python 2.7 setup on macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-latest, macos-11]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-11
           - ubuntu-latest
           - windows-latest
         python-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
+          - macos-10.15
           - ubuntu-latest
           - windows-latest
         python-version:


### PR DESCRIPTION
This fixes the Python 2.7 jobs on macOS.  master is currently quite broken, as visible on https://github.com/tahoe-lafs/zfec/pull/54 (old master builds are not fair comparisons because external stuff has changed and broken a lot of things).

Compared to #54 (9 failing, 2 cancelled, 23 successful), this is a reasonable improvement (6 failing, 2 cancelled, 26 successful).

Don't ask me about the cancelled jobs, I have no idea.


