### PR TITLE
Remove the unnecessary dependency on argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,6 @@ setup(
     description="An efficient, portable erasure coding tool",
     long_description=open('README.rst', 'r').read(),
     url="https://github.com/tahoe-lafs/zfec",
-    install_requires=[
-        "argparse >= 0.8",
-    ],
     extras_require={
         "bench": ["pyutil >= 3.0.0"],
         "test": ["twisted", "setuptools_trial", "pyutil >= 3.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,7 @@ extensions = [
 
 # Most of our metadata lives in setup.cfg [metadata]. We put "name" here
 # because the setuptools-22.0.5 on slackware can't find it there, which breaks
-# packaging. We put "version" here so that Versioneer works correctly, and
-# "install_requires" because I don't know how to express the python_version
-# clause within the setup.cfg syntax.
-
+# packaging. We put "version" here so that Versioneer works correctly.
 setup(
     name="zfec",
     version=versioneer.get_version(),


### PR DESCRIPTION
It was added to the Python stdlib in 2.7 and 3.2 so zfec can always get it from the standard library.

Fixes #50 