### PR TITLE
Run for push to master, not other pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ on:
   # Do build on pushes to any branch with an open pull request.
   pull_request:
 
+  # Do build on different release events
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
   release:
     types: [published, created, edited]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
     # Do build on pushes to any release tag
     tags:
       - "zfec-.*"
+
+  # Do build on pushes to any branch with an open pull request.
+  pull_request:
+
   release:
     types: [published, created, edited]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,11 @@ name: Build Python packages
 
 on:
   push:
+    # Don't build on pushes to arbitrary branches
+    branches:
+    # Do build on pushes to any release tag
     tags:
+      - "zfec-.*"
   release:
     types: [published, created, edited]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,12 @@ name: Build Python packages
 
 on:
   push:
-    # Don't build on pushes to arbitrary branches
     branches:
-      # The ! prefix makes this an exclusion.  Exclude everything.
-      - "!.*"
+      # Do build on pushes to master.
+      - "master"
 
-    # Do build on pushes to any release tag
     tags:
+      # Do build on pushes to any release tag
       - "zfec-.*"
 
   # Do build on pushes to any branch with an open pull request.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,9 @@ name: Build Python packages
 on:
   push:
     # Don't build on pushes to arbitrary branches
-    branches: []
+    branches:
+      # The ! prefix makes this an exclusion.  Exclude everything.
+      - "!.*"
 
     # Do build on pushes to any release tag
     tags:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ name: Build Python packages
 on:
   push:
     # Don't build on pushes to arbitrary branches
-    branches:
+    branches: []
+
     # Do build on pushes to any release tag
     tags:
       - "zfec-.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Run tests
 
 on:
   push:
+    branches:
+      - "master"
   pull_request:
 
 jobs:


### PR DESCRIPTION
This removes the double CI runs for pushes to any open PR.  Previously every push to a PR ran 34 jobs.  Now every push to a PR runs 19 jobs.  Previously every push to a non-PR branch ran some jobs.  Now it the only branch it runs them for is master.
