### PR TITLE
Fix macOS and Windows wheel building jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,11 +48,11 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.4
+          python3 -m pip install cibuildwheel==2.3.1
 
       - name: Build wheels
         run: |
-          python -m cibuildwheel --output-dir wheelhouse
+          python3 -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v2
         name: Upload artifacts
@@ -73,7 +73,8 @@ jobs:
           python-version: '3.7'
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: |
+          python3 setup.py sdist
 
       - uses: actions/upload-artifact@v2
         name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: "${{ matrix.wheel-selector }} wheel on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -55,7 +55,7 @@ jobs:
         run: |
           python3 -m pip install cibuildwheel==2.3.1
 
-      - name: "Build wheel ${{ matrix.wheel-selector }}"
+      - name: "Run cibuildwheel"
         env:
           # Configure cibuildwheel to build just some of the total wheels we
           # could build for this architecture.  This yields better parallelism

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           python3 -m pip install cibuildwheel==2.3.1
 
-      - name: "Build wheels for ${{ matrix.wheel-selector }}"
+      - name: "Build wheel ${{ matrix.wheel-selector }}"
         env:
           # Configure cibuildwheel to build just some of the total wheels we
           # could build for this architecture.  This yields better parallelism

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,6 @@ env:
   # Just make sure that Python can use zfec package
   CIBW_TEST_COMMAND: python -c "import zfec; print(zfec.__version__)"
 
-  # Twisted isn't quite ready on Windows Python 3.9
-  CIBW_SKIP: cp39-win*
-
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -35,7 +32,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-11]
+        os:
+          - "ubuntu-18.04"
+          - "windows-latest"
+          - "macos-11"
+        wheel-selector:
+          - "cp37-*"
+          - "cp38-*"
+          - "cp39-*"
+          - "cp310-*"
 
     steps:
       - uses: actions/checkout@v2
@@ -51,6 +56,12 @@ jobs:
           python3 -m pip install cibuildwheel==2.3.1
 
       - name: Build wheels
+        env:
+          # Configure cibuildwheel to build just some of the total wheels we
+          # could build for this architecture.  This yields better parallelism
+          # on GitHub Actions execution.
+          CIBW_BUILD: "${{ matrix.wheel-selector }}"
+
         run: |
           python3 -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 # Build sdist+wheel packages using GitHub Actions.  Mostly adopted
 # from https://cibuildwheel.readthedocs.io/en/stable/setup/
 
-name: Build Python packages
+name: "Packages"
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           python3 -m pip install cibuildwheel==2.3.1
 
-      - name: Build wheels
+      - name: "Build wheels for ${{ matrix.wheel-selector }}"
         env:
           # Configure cibuildwheel to build just some of the total wheels we
           # could build for this architecture.  This yields better parallelism

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: "Tests"
 
 on:
   push:


### PR DESCRIPTION
Change to a newer cibuildwheel, now that we don't need to build Python 2 wheels, and run it with Python 3.  This fixes both macOS and Windows wheel building.
