### PR TITLE
Remove tox from ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python packages
+      - name: "Run unit tests"
         run: |
-          pip install --upgrade tox setuptools
-          pip list
-
-      - name: Run "tox -e py"
-        run: tox -e py
+          pip install .[test]
+          python -m twisted.trial zfec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
       - name: "Run unit tests"
         run: |
           pip install .[test]
-          python -m twisted.trial zfec
+          trial zfec

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     url="https://github.com/tahoe-lafs/zfec",
     extras_require={
         "bench": ["pyutil >= 3.0.0"],
-        "test": ["twisted", "setuptools_trial", "pyutil >= 3.0.0"],
+        "test": ["twisted", "pyutil >= 3.0.0"],
     },
     ext_modules=extensions,
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
tox is barely doing anything useful for CI while adding a lot of extra conceptual overhead.  This removes it and just runs trial directly.