### PR TITLE
Fix compiler type warnings

### DIFF
--- a/zfec/_fecmodule.c
+++ b/zfec/_fecmodule.c
@@ -134,7 +134,7 @@ Encoder_encode(Encoder *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "O|O:Encoder.encode", &inblocks, &desired_blocks_nums))
         return NULL;
 
-    for (i = 0; i < self->mm - self->kk; i++)
+    for (i = 0; i < (size_t)self->mm - (size_t)self->kk; i++)
         pystrs_produced[i] = NULL;
 
     if (desired_blocks_nums) {

--- a/zfec/fec.c
+++ b/zfec/fec.c
@@ -444,7 +444,7 @@ fec_new(unsigned short k, unsigned short n) {
     tmp_m[0] = 1;
     for (col = 1; col < k; col++)
         tmp_m[col] = 0;
-    for (p = tmp_m + k, row = 0; row < n - 1; row++, p += k)
+    for (p = tmp_m + k, row = 0; row + 1 < n; row++, p += k)
         for (col = 0; col < k; col++)
             p[col] = gf_exp[modnn (row * col)];
 


### PR DESCRIPTION
This fixes some compiler warnings but not the Python API deprecation warnings.

Fixes #48 