### PR TITLE
Add _addmul1 ARM Neon implementation

### DIFF
--- a/.github/workflows/test-qemu.yml
+++ b/.github/workflows/test-qemu.yml
@@ -1,0 +1,34 @@
+name: "QEMU tests"
+
+on:
+  push:
+    branches:
+      - "simd"
+  pull_request:
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+
+      - name: Check out zfec sources
+        uses: actions/checkout@v2
+        with:
+          ref: simd
+
+      - name: "Run unit tests on QEMU (cortex-a8)"
+        uses: pguyot/arm-runner-action@v2
+        with:
+          base_image: raspios_lite:latest
+          cpu: cortex-a8
+          optimize_image: no
+          commands: |
+            sudo apt-get --yes update
+            sudo apt-get --yes install python3-pip
+            yes | pip install twisted pyutil
+            yes | pip install --verbose --install-option=--with-arm-neon .[test]
+            trial zfec

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,16 @@ extra_compile_args = []
 define_macros = []
 undef_macros = []
 
-for arg in sys.argv:
+for arg in sys.argv[:]:
     if arg.startswith("--stride="):
         stride = int(arg[len("--stride="):])
         define_macros.append(('STRIDE', stride))
         sys.argv.remove(arg)
-        break
+    elif arg == "--with-arm-neon":
+        extra_compile_args.append("-mfpu=neon")
+        define_macros.append(('ZFEC_USE_ARM_NEON', None))
+        sys.argv.remove(arg)
+
 
 extra_compile_args.append("-std=c99")
 if DEBUGMODE:

--- a/zfec/fec.c
+++ b/zfec/fec.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 
@@ -64,6 +65,9 @@ static gf gf_mul_table[256][256];
 #define GF_MULC0(c) __gf_mulc_ = gf_mul_table[c]
 #define GF_ADDMULC(dst, x) dst ^= __gf_mulc_[x]
 
+/* gf_mul_table_16[c][x] = gf_mul_table[c][x << 4] */
+static gf gf_mul_table_16[256][16];
+
 /*
  * Generate GF(2**m) from the irreducible polynomial p(X) in p[0]..p[m]
  * Lookup tables:
@@ -83,6 +87,10 @@ _init_mul_table(void) {
 
   for (j = 0; j < 256; j++)
       gf_mul_table[0][j] = gf_mul_table[j][0] = 0;
+
+  for (i = 0; i < 256; i++)
+      for (j = 0; j < 16; j++)
+          gf_mul_table_16[i][j] = gf_mul_table[i][j << 4];
 }
 
 #define NEW_GF_MATRIX(rows, cols) \
@@ -174,6 +182,56 @@ _addmul1(register gf*restrict dst, const register gf*restrict src, gf c, size_t 
 
     GF_MULC0 (c);
 
+#if defined(ZFEC_USE_ARM_NEON) && UNROLL == 16
+    // Idea from https://botan.randombit.net zfec_vperm.cpp
+    
+    const gf * const gf_mulc_16 = gf_mul_table_16[c];
+    
+    /* align dst to 16 bytes */
+    while(sz && (uintptr_t)dst % 16) {
+        GF_ADDMULC (*dst, *src);
+        dst++;
+        src++;
+        sz--;
+    }
+    /* 
+     * for (; dst < lim; dst += 16, src += 16) {
+     *   // 16x parallel
+     *   for (int i = 0; i < 16; i++) {
+     *     dst[i] ^= __gf_mulc_[src[i] & 0x0f] ^ gf_mulc_16[src[i] >> 4];
+     *   }
+     * }
+     * dst should be aligned to 16 bytes
+     */
+    __asm__(
+        "vmov.i8  q0, #0x0f              \n\t"  // q0 = 0x0f0f...0f
+        "vld1.8   {q3}, [%[gf_mulc]]     \n\t"  // q3 = gf_mulc[0..15]
+        "vld1.8   {q8}, [%[gf_mulc_16]]  \n\t"  // q8 = gf_mulc_16[0..15]
+    "1:                                  \n\t"  //
+        "cmp      %[dst], %[lim]         \n\t"  //
+        "bhs      2f                     \n\t"  // while (dst < lim) {
+        "vld1.8   {q2}, [%[src]]!        \n\t"  //   q2 = src[0..15];  src += 16
+        "vld1.8   {q1}, [%[dst]:128]     \n\t"  //   q1 = dst[0..15]
+        "vand.8   q9, q2, q0             \n\t"  //   q9 = src & 0x0f0f...0f
+        "vtbl.8   d18, {q3}, d18         \n\t"  //
+        "vshr.u8  q10, q2, #4            \n\t"  //   q10 = src >> 4
+        "vtbl.8   d19, {q3}, d19         \n\t"  //   q9 = gf_mulc[q9]
+        "vtbl.8   d20, {q8}, d20         \n\t"  //
+        "vtbl.8   d21, {q8}, d21         \n\t"  //   q10 = gf_mulc_16[q10]
+        "veorq.8  q1, q9                 \n\t"  //
+        "veorq.8  q1, q10                \n\t"  //
+        "vst1.8   {q1}, [%[dst]:128]!    \n\t"  //   dst[0..15] ^= q9 ^ q10;  dst += 16
+        "b        1b                     \n\t"  //
+    "2:                                  \n\t"  // }
+        : [dst]"+r"(dst),
+          [src]"+r"(src)
+        : [lim]       "r"(lim),
+          [gf_mulc]   "r"(__gf_mulc_),
+          [gf_mulc_16]"r"(gf_mulc_16)
+        : "q0", "q1", "q2", "q3", "q8", "q9", "q10", "memory", "cc"
+    );
+
+#else
 #if (UNROLL > 1)                /* unrolling by 8/16 is quite effective on the pentium */
     for (; dst < lim; dst += UNROLL, src += UNROLL) {
         GF_ADDMULC (dst[0], src[0]);
@@ -198,6 +256,8 @@ _addmul1(register gf*restrict dst, const register gf*restrict src, gf c, size_t 
 #endif
     }
 #endif
+#endif
+
     lim += UNROLL - 1;
     for (; dst < lim; dst++, src++)       /* final components */
         GF_ADDMULC (*dst, *src);


### PR DESCRIPTION
The `simd` branch adds, for now, ARM NEON assembly for `_addmul1`, enabled by `--with-arm-neon` in `setup.py`.

Benchmark results on a 1 GHz Cortex-A8 (AM335x, Beaglebone Black)
Without Neon:
```
$ rm -rf build; PYTHONPATH=inst python2 setup.py develop --install-dir=inst --stride=512
...

$ PYTHONPATH=inst python2 bench/bench_zfec.py
measuring encoding of data with K=3, M=10, reporting results in nanoseconds per byte after encoding 1000000 bytes 8 times in a row...
best: 5.064e+01,   3th-best: 5.066e+01, mean: 5.074e+01,   3th-worst: 5.071e+01, worst: 5.128e+01 (of     10)
and now represented in MB/s...

best:   19.748 MB/sec
mean:   19.707 MB/sec
worst:  19.499 MB/sec

$ PYTHONPATH=inst python2 bench/bench_zfec.py --k=223 --m=255
measuring encoding of data with K=223, M=255, reporting results in nanoseconds per byte after encoding 1000000 bytes 8 times in a row...
best: 1.751e+02,   3th-best: 1.761e+02, mean: 1.767e+02,   3th-worst: 1.769e+02, worst: 1.786e+02 (of     10)
and now represented in MB/s...

best:   5.710 MB/sec
mean:   5.660 MB/sec
worst:  5.598 MB/sec
```
With Neon:
```
$ rm -rf build; PYTHONPATH=inst python2 setup.py develop --install-dir=inst --stride=512 --with-arm-neon
...

$ PYTHONPATH=inst python2 bench/bench_zfec.py
measuring encoding of data with K=3, M=10, reporting results in nanoseconds per byte after encoding 1000000 bytes 8 times in a row...
best: 2.986e+01,   3th-best: 3.032e+01, mean: 3.031e+01,   3th-worst: 3.040e+01, worst: 3.041e+01 (of     10)
and now represented in MB/s...

best:   33.490 MB/sec
mean:   32.989 MB/sec
worst:  32.886 MB/sec

$ PYTHONPATH=inst python2 bench/bench_zfec.py --k=223 --m=255
measuring encoding of data with K=223, M=255, reporting results in nanoseconds per byte after encoding 1000000 bytes 8 times in a row...
best: 9.081e+01,   3th-best: 9.132e+01, mean: 9.402e+01,   3th-worst: 9.623e+01, worst: 9.703e+01 (of     10)
and now represented in MB/s...

best:   11.012 MB/sec
mean:   10.637 MB/sec
worst:  10.306 MB/sec
```
