### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
       # Download all artifacts previously built by this workflow to the dist
       # directory where the publish step can find them.  These are the sdist
       # and all of the wheels build by the other jobs.
-      - uses: "actions/download-artifact@v2"
+      - uses: "actions/download-artifact@v3"
         with:
           name: "artifact"
           path: "dist"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           python3 -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Upload artifacts
         with:
           path: ./wheelhouse/*.whl
@@ -104,7 +104,7 @@ jobs:
         run: |
           python3 setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Upload artifacts
         with:
           path: dist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,6 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
-          cache: 'pip' # caching pip dependencies
-          cache-dependency-path: 'setup.py'
 
       - name: Build sdist
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,27 +54,15 @@ jobs:
           # construct non-release version numbers.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
-        name: Install Python
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
         with:
-          python-version: '3.7'
-          cache: 'pip' # caching pip dependencies
-          cache-dependency-path: 'setup.py'
-
-      - name: Install cibuildwheel
-        run: |
-          python3 -m pip install cibuildwheel==2.3.1
-          python -m cibuildwheel --print-build-identifiers
-
-      - name: "Run cibuildwheel"
+          output-dir: wheelhouse
         env:
           # Configure cibuildwheel to build just some of the total wheels we
           # could build for this architecture.  This yields better parallelism
           # on GitHub Actions execution.
           CIBW_BUILD: "${{ matrix.wheel-selector }}"
-
-        run: |
-          python3 -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v3
         name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Check out zfec sources
         with:
           # Check out the full history, including tags.  This is necessary to

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-18.04"
-          - "windows-latest"
           - "macos-11"
+          - "ubuntu-22.04"
+          - "windows-2022"
         wheel-selector:
           - "cp37-*"
           - "cp38-*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
       #
       # The conditional in this step should cause it to run only for case (3).
       - name: "Publish to TEST PyPI"
-        uses: "pypa/gh-action-pypi-publish@master"
+        uses: "pypa/gh-action-pypi-publish@v1.6.4"
         if: >-
           github.event_name == 'pull_request'
 
@@ -162,7 +162,7 @@ jobs:
       # instance.  This time, we have a conditional that runs only for case
       # (2).
       - name: "Publish to LIVE PyPI"
-        uses: "pypa/gh-action-pypi-publish@master"
+        uses: "pypa/gh-action-pypi-publish@v1.6.4"
         if: >-
           github.event_name == 'push' &&
           startsWith(github.event.ref, 'refs/tags/zfec-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ on:
   release:
     types: [published, created, edited]
 
-env:
-  # Just make sure that Python can use zfec package
-  CIBW_TEST_COMMAND: python -c "import zfec; print(zfec.__version__)"
 
 jobs:
   build_wheels:
@@ -63,6 +60,8 @@ jobs:
           # could build for this architecture.  This yields better parallelism
           # on GitHub Actions execution.
           CIBW_BUILD: "${{ matrix.wheel-selector }}"
+          # Just make sure that Python can use zfec package.
+          CIBW_TEST_COMMAND: python -c "import zfec; print(zfec.__version__)"
 
       - uses: actions/upload-artifact@v3
         name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Check out zfec sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Check out the full history, including tags.  This is necessary to
           # construct non-release version numbers.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           # construct non-release version numbers.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.7'
@@ -91,7 +91,7 @@ jobs:
           # construct non-release version numbers.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.7'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,11 @@ jobs:
   build_wheels:
     name: "${{ matrix.wheel-selector }} wheel on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
+      # NOTE: when updating the matrix below, be sure to keep OS and
+      # Python versions in sync with the ones in test.yml.
       matrix:
         os:
           - "macos-11"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: 'setup.py'
 
       - name: Install cibuildwheel
         run: |
@@ -95,6 +97,8 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: 'setup.py'
 
       - name: Build sdist
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.11'
 
       - name: Build sdist
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
 
       - name: Check out zfec sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-10.15
-          - ubuntu-latest
-          - windows-latest
+          - "macos-11"
+          - "ubuntu-22.04"
+          - "windows-2022"
         python-version:
           - "3.7"
           - "3.8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: 'setup.py'
 
       - name: "Run unit tests"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,11 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
+      # NOTE: when updating the matrix below, be sure to keep OS and
+      # Python versions in sync with the ones in build.yml.
       matrix:
         os:
           - "macos-11"


### PR DESCRIPTION
Summary of changes:

- Update actions that cause deprecation warnings.
- Use pip caches when possible.
- Update OSes. Use same OSes in both test and build workflows, and be explicit about which OS we use.
- Use cibuildwheel action instead of `pip install`-ing cibuildwheel.  There's less boilerplate this way.

Addresses issue #76, supercedes PR #75.  Will follow up with PRs that address #74 and #77 once if/when this gets merged.