### PR TITLE
Haskell binding parameter validation fixes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/fec.cabal
+++ b/fec.cabal
@@ -1,30 +1,56 @@
-name:            fec
-version:         0.1.1
-license:         GPL
-license-file:    README.rst
-author:          Adam Langley <agl@imperialviolet.org>
-maintainer:      Adam Langley <agl@imperialviolet.org>
-description:     This code, based on zfec by Zooko, based on code by Luigi
-		 Rizzo implements an erasure code, or forward error
-		 correction code. The most widely known example of an erasure
-		 code is the RAID-5 algorithm which makes it so that in the
-		 event of the loss of any one hard drive, the stored data can
-		 be completely recovered.  The algorithm in the zfec package
-		 has a similar effect, but instead of recovering from the loss
-		 of only a single element, it can be parameterized to choose in
-		 advance the number of elements whose loss it can tolerate.
-build-type:      Simple
-homepage:        http://allmydata.org/source/zfec
-synopsis:        Forward error correction of ByteStrings
-category:        Codec
-build-depends:   base, bytestring>=0.9
-stability:       provisional
-tested-with:     GHC == 6.8.2
-exposed-modules: Codec.FEC
-extensions:      ForeignFunctionInterface
-hs-source-dirs:  haskell
-ghc-options:     -Wall
-c-sources:       zfec/fec.c
-cc-options:      -std=c99
-include-dirs:    zfec
-extra-source-files: zfec/fec.h, COPYING.GPL, COPYING.TGPPL.rst
+cabal-version:      3.4
+name:               fec
+version:            0.1.1
+license:            GPL-2.0-or-later
+license-file:       README.rst
+author:             Adam Langley <agl@imperialviolet.org>
+maintainer:         Adam Langley <agl@imperialviolet.org>
+description:
+  This code, based on zfec by Zooko, based on code by Luigi
+  Rizzo implements an erasure code, or forward error
+  correction code. The most widely known example of an erasure
+  code is the RAID-5 algorithm which makes it so that in the
+  event of the loss of any one hard drive, the stored data can
+  be completely recovered.  The algorithm in the zfec package
+  has a similar effect, but instead of recovering from the loss
+  of only a single element, it can be parameterized to choose in
+  advance the number of elements whose loss it can tolerate.
+
+build-type:         Simple
+homepage:           https://github.com/tahoe-lafs/zfec
+synopsis:           Forward error correction of ByteStrings
+category:           Codec
+stability:          provisional
+tested-with:        GHC ==6.8.2
+extra-source-files:
+  COPYING.GPL
+  COPYING.TGPPL.rst
+  zfec/fec.h
+
+library
+  build-depends:
+    , base
+    , bytestring  >=0.9
+
+  exposed-modules:    Codec.FEC
+  default-extensions: ForeignFunctionInterface
+  hs-source-dirs:     haskell
+  ghc-options:        -Wall
+  c-sources:          zfec/fec.c
+  cc-options:         -std=c99
+  include-dirs:       zfec
+
+test-suite tests
+  type:             exitcode-stdio-1.0
+  main-is:          FECTest.hs
+  other-modules:
+  hs-source-dirs:   haskell/test
+  ghc-options:      -Wall -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base
+    , bytestring
+    , fec
+    , QuickCheck
+    , random
+
+  default-language: Haskell2010

--- a/fec.cabal
+++ b/fec.cabal
@@ -53,5 +53,6 @@ test-suite tests
     , hspec
     , QuickCheck
     , random
+    , data-serializer
 
   default-language: Haskell2010

--- a/fec.cabal
+++ b/fec.cabal
@@ -49,10 +49,11 @@ test-suite tests
   build-depends:
     , base
     , bytestring
+    , data-serializer
     , fec
     , hspec
     , QuickCheck
+    , quickcheck-instances
     , random
-    , data-serializer
 
   default-language: Haskell2010

--- a/fec.cabal
+++ b/fec.cabal
@@ -50,6 +50,7 @@ test-suite tests
     , base
     , bytestring
     , fec
+    , hspec
     , QuickCheck
     , random
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,164 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "hs-flake-utils",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hs-flake-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1671550653,
+        "narHash": "sha256-bDyzhrlvHLwoIZVhti1y/F82NlE2bm9lKnPq/TrZ/bw=",
+        "ref": "main",
+        "rev": "11ef7d39b50d523f2991a056bb9211bf5eb3d9ac",
+        "revCount": 1,
+        "type": "git",
+        "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1670543317,
+        "narHash": "sha256-4mMR56rtxKr+Gwz399jFr4i76SQZxsLWxxyfQlPXRm0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7a6a010c3a1d00f8470a5ca888f2f927f1860a19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1671271954,
+        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "hs-flake-utils",
+          "flake-utils"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "hs-flake-utils",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1671452357,
+        "narHash": "sha256-HqzXiQEegpRQ4VEl9pEPgHSIxhJrNJ27HfN1wOc7w2E=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "200790e9c77064c53eaf95805b013d96615ecc27",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "hs-flake-utils": "hs-flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1671550653,
-        "narHash": "sha256-bDyzhrlvHLwoIZVhti1y/F82NlE2bm9lKnPq/TrZ/bw=",
+        "lastModified": 1673454489,
+        "narHash": "sha256-LsOintvQ4n3QPkI5MA+IhmlLlH5BVzL2xqT/h5U5K7w=",
         "ref": "main",
-        "rev": "11ef7d39b50d523f2991a056bb9211bf5eb3d9ac",
-        "revCount": 1,
+        "rev": "4feccf13501960b92e1d9d73bf6e046b36861af0",
+        "revCount": 4,
         "type": "git",
         "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
       },
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1671452357,
-        "narHash": "sha256-HqzXiQEegpRQ4VEl9pEPgHSIxhJrNJ27HfN1wOc7w2E=",
+        "lastModified": 1673281605,
+        "narHash": "sha256-v6U0G3pJe0YaIuD1Ijhz86EhTgbXZ4f/2By8sLqFk4c=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "200790e9c77064c53eaf95805b013d96615ecc27",
+        "rev": "f8992fb404c7e79638192a10905b7ea985818050",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "An efficient, portable erasure coding tool";
+
+  inputs = {
+    # Nix Inputs
+    nixpkgs.url = github:nixos/nixpkgs/?ref=nixos-22.11;
+    flake-utils.url = github:numtide/flake-utils;
+    hs-flake-utils.url = "git+https://whetstone.private.storage/jcalderone/hs-flake-utils.git?ref=main";
+    hs-flake-utils.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    hs-flake-utils,
+  }: let
+    ulib = flake-utils.lib;
+  in
+    ulib.eachSystem ["x86_64-linux"] (system: let
+      hslib = hs-flake-utils.lib {
+        pkgs = nixpkgs.legacyPackages.${system};
+        src = ./.;
+        compilerVersion = "ghc8107";
+        packageName = "fec";
+      };
+    in {
+      checks = hslib.checks {};
+      devShells = hslib.devShells {};
+      packages = hslib.packages {};
+    });
+}

--- a/haskell/Codec/FEC.hs
+++ b/haskell/Codec/FEC.hs
@@ -73,7 +73,7 @@ foreign import ccall unsafe "fec_decode" _decode :: Ptr CFEC
 -- | Return true if the given @k@ and @n@ values are valid
 isValidConfig :: Int -> Int -> Bool
 isValidConfig k n
-  | k >= n = False
+  | k > n = False
   | k < 1 = False
   | n < 1 = False
   | n > 255 = False

--- a/haskell/Codec/FEC.hs
+++ b/haskell/Codec/FEC.hs
@@ -15,7 +15,7 @@
 -- numbered 0..(n - 1) and blocks numbered < k are the primary blocks.
 
 module Codec.FEC (
-    FECParams
+    FECParams(paramK, paramN)
   , fec
   , encode
   , decode
@@ -43,7 +43,11 @@ import System.IO (withFile, IOMode(..))
 import System.IO.Unsafe (unsafePerformIO)
 
 data CFEC
-data FECParams = FECParams (ForeignPtr CFEC) Int Int
+data FECParams = FECParams
+  { cfec   :: (ForeignPtr CFEC)
+  , paramK :: Int
+  , paramN :: Int
+  }
 
 instance Show FECParams where
   show (FECParams _ k n) = "FEC (" ++ show k ++ ", " ++ show n ++ ")"

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -1,57 +1,65 @@
 module Main where
 
-import qualified Data.ByteString as B
 import qualified Codec.FEC as FEC
-import System.IO (withFile, IOMode(..))
-import System.Random
+import qualified Data.ByteString as B
 import Data.List (sortBy)
+import System.IO (IOMode (..), withFile)
+import System.Random
 
 import Test.QuickCheck
 
 -- | Return true if the given @k@ and @n@ values are valid
 isValidConfig :: Int -> Int -> Bool
 isValidConfig k n
-  | k >= n = False
-  | k < 1 = False
-  | n < 1 = False
-  | otherwise = True
+    | k >= n = False
+    | k < 1 = False
+    | n < 1 = False
+    | otherwise = True
 
 randomTake :: Int -> Int -> [a] -> [a]
-randomTake seed n values = map snd $ take n sortedValues where
-  sortedValues = sortBy (\a b -> compare (fst a) (fst b)) taggedValues
-  taggedValues = zip rnds values
-  rnds :: [Float]
-  rnds = randoms gen
-  gen = mkStdGen seed
+randomTake seed n values = map snd $ take n sortedValues
+  where
+    sortedValues = sortBy (\a b -> compare (fst a) (fst b)) taggedValues
+    taggedValues = zip rnds values
+    rnds :: [Float]
+    rnds = randoms gen
+    gen = mkStdGen seed
 
-testFEC k n len seed = FEC.decode fec someTaggedBlocks == origBlocks where
-  origBlocks = map (\i -> B.replicate len $ fromIntegral i) [0..(k - 1)]
-  fec = FEC.fec k n
-  secondaryBlocks = FEC.encode fec origBlocks
-  taggedBlocks = zip [0..] (origBlocks ++ secondaryBlocks)
-  someTaggedBlocks = randomTake seed k taggedBlocks
+testFEC k n len seed = FEC.decode fec someTaggedBlocks == origBlocks
+  where
+    origBlocks = map (\i -> B.replicate len $ fromIntegral i) [0 .. (k - 1)]
+    fec = FEC.fec k n
+    secondaryBlocks = FEC.encode fec origBlocks
+    taggedBlocks = zip [0 ..] (origBlocks ++ secondaryBlocks)
+    someTaggedBlocks = randomTake seed k taggedBlocks
 
 prop_FEC :: Int -> Int -> Int -> Int -> Property
 prop_FEC k n len seed =
-  isValidConfig k n && n < 256 && len < 1024 ==> testFEC k n len seed
+    isValidConfig k n && n < 256 && len < 1024 ==> testFEC k n len seed
 
 checkDivide :: Int -> IO ()
 checkDivide n = do
-  let input = B.replicate 1024 65
-  parts <- FEC.secureDivide n input
-  if FEC.secureCombine parts == input
-     then return ()
-     else fail "checkDivide failed"
+    let input = B.replicate 1024 65
+    parts <- FEC.secureDivide n input
+    if FEC.secureCombine parts == input
+        then return ()
+        else fail "checkDivide failed"
 
 checkEnFEC :: Int -> IO ()
 checkEnFEC len = do
-  testdata <- withFile "/dev/urandom" ReadMode (\handle -> B.hGet handle len)
-  let [a, b, c, d, e] = FEC.enFEC 3 5 testdata
-  if FEC.deFEC 3 5 [b, e, d] == testdata
-     then return ()
-     else fail "deFEC failure"
+    testdata <- withFile "/dev/urandom" ReadMode (\handle -> B.hGet handle len)
+    let [a, b, c, d, e] = FEC.enFEC 3 5 testdata
+    if FEC.deFEC 3 5 [b, e, d] == testdata
+        then return ()
+        else fail "deFEC failure"
 
 main = do
-  mapM_ (check (defaultConfig { configMaxTest = 1000, configMaxFail = 10000 })) [prop_FEC]
-  mapM_ checkDivide [1, 2, 3, 4, 10]
-  mapM_ checkEnFEC [1, 2, 3, 4, 5, 1024 * 1024]
+    mapM_
+        (check (defaultConfig{configMaxTest = 1000, configMaxFail = 10000}))
+        [prop_FEC]
+        mapM_
+        checkDivide
+        [1, 2, 3, 4, 10]
+        mapM_
+        checkEnFEC
+        [1, 2, 3, 4, 5, 1024 * 1024]

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -5,6 +5,7 @@ module Main where
 
 import Test.Hspec
 
+import Data.Word
 import qualified Data.ByteString.Lazy as BL
 import qualified Codec.FEC as FEC
 import qualified Data.ByteString as B
@@ -13,8 +14,8 @@ import System.IO (IOMode (..), withFile)
 import System.Random
 import Data.Int
 import Data.Serializer
-
 import Test.QuickCheck
+
 newtype ArbByteString = ArbByteString BL.ByteString deriving newtype (Show, Ord, Eq)
 
 instance Arbitrary ArbByteString where
@@ -40,6 +41,11 @@ instance Arbitrary Params where
         total <- choose (min 255 (required + 1), 255)
         return $ Params required total
 
+instance Arbitrary FEC.FECParams where
+    arbitrary = do
+      (Params required total) <- arbitrary :: Gen Params
+      return $ FEC.fec required total
+
 randomTake :: Int -> Int -> [a] -> [a]
 randomTake seed n values = map snd $ take n sortedValues
   where
@@ -49,17 +55,38 @@ randomTake seed n values = map snd $ take n sortedValues
     rnds = randoms gen
     gen = mkStdGen seed
 
-testFEC :: Int -> Int -> Int -> Int -> Bool
-testFEC k n len seed = FEC.decode fec someTaggedBlocks == origBlocks
+-- | Any combination of the inputs blocks and the output blocks from
+-- @FEC.encode@, as long as there are at least @k@ of them, can be recombined
+-- using @FEC.decode@ to produce the original input blocks.
+--
+testFEC
+  :: FEC.FECParams
+  -- ^ The FEC parameters to exercise.
+  -> Word16
+  -- ^ The length of the blocks to exercise.
+  -> Int
+  -- ^ A random seed to use to be able to vary the choice of which blocks to
+  -- try to decode.
+  -> Bool
+  -- ^ True if the encoded input was reconstructed by decoding, False
+  -- otherwise.
+testFEC fec len seed = FEC.decode fec someTaggedBlocks == origBlocks
   where
-    origBlocks = map (\i -> B.replicate len $ fromIntegral i) [0 .. (k - 1)]
-    fec = FEC.fec k n
-    secondaryBlocks = FEC.encode fec origBlocks
-    taggedBlocks = zip [0 ..] (origBlocks ++ secondaryBlocks)
-    someTaggedBlocks = randomTake seed k taggedBlocks
+    -- Construct some blocks.  Each will just be the byte corresponding to the
+    -- block number repeated to satisfy the requested length.
+    origBlocks = B.replicate (fromIntegral len) . fromIntegral <$> [0 .. (FEC.paramK fec - 1)]
 
-prop_FEC :: Params -> Int -> Int -> Property
-prop_FEC (Params k n) len seed = len < 1024 ==> testFEC k n len seed
+    -- Encode the data to produce the "secondary" blocks which (might) add
+    -- redundancy to the original blocks.
+    secondaryBlocks = FEC.encode fec origBlocks
+
+    -- Tag each block with its block number because the decode API requires
+    -- this information.
+    taggedBlocks = zip [0 ..] (origBlocks ++ secondaryBlocks)
+
+    -- Choose enough of the tagged blocks (some combination of original and
+    -- secondary) to try to use for decoding.
+    someTaggedBlocks = randomTake seed (FEC.paramK fec) taggedBlocks
 
 checkDivide :: Int -> IO ()
 checkDivide n = do
@@ -69,6 +96,8 @@ checkDivide n = do
         then return ()
         else fail "checkDivide failed"
 
+prop_decode :: FEC.FECParams -> Word16 -> Int -> Property
+prop_decode fec len seed = len < 1024 ==> testFEC fec len seed
 
 prop_deFEC :: Params -> ArbByteString -> Property
 prop_deFEC (Params required total) (ArbByteString testdata) =
@@ -82,7 +111,10 @@ main :: IO ()
 main = hspec $ do
     describe "FEC" $ do
         it "secureCombine is the inverse of secureDivide n" $ mapM_ checkDivide [1, 2, 3, 4, 10]
-        it "decode is (nearly) the inverse of encode" $ (withMaxSuccess 5000 prop_FEC)
     describe "deFEC" $ do
         it "is the inverse of enFEC" $ (withMaxSuccess 2000 prop_deFEC)
 
+    describe "decode" $ do
+        it "is (nearly) the inverse of encode" $ (withMaxSuccess 2000 prop_decode)
+        it "works with total=256" $ property $ prop_decode (FEC.fec 1 256)
+        it "works with required=256" $ property $ prop_decode (FEC.fec 256 256)

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -1,5 +1,7 @@
 module Main where
 
+import Test.Hspec
+
 import qualified Codec.FEC as FEC
 import qualified Data.ByteString as B
 import Data.List (sortBy)
@@ -8,7 +10,10 @@ import System.Random
 
 import Test.QuickCheck
 
--- | Return true if the given @k@ and @n@ values are valid
+{- | Return true if the given @k@ and @n@ values are valid ZFEC encoding
+ parameters.  They are valid if they in [1..256] and if @k@ is no greater
+ than @n@.
+-}
 isValidConfig :: Int -> Int -> Bool
 isValidConfig k n
     | k >= n = False
@@ -25,6 +30,7 @@ randomTake seed n values = map snd $ take n sortedValues
     rnds = randoms gen
     gen = mkStdGen seed
 
+testFEC :: Int -> Int -> Int -> Int -> Bool
 testFEC k n len seed = FEC.decode fec someTaggedBlocks == origBlocks
   where
     origBlocks = map (\i -> B.replicate len $ fromIntegral i) [0 .. (k - 1)]
@@ -54,7 +60,8 @@ checkEnFEC len = do
         else fail "deFEC failure"
 
 main :: IO ()
-main = do
-    mapM_ quickCheck [prop_FEC]
-    mapM_ checkDivide [1, 2, 3, 4, 10]
-    mapM_ checkEnFEC [1, 2, 3, 4, 5, 1024 * 1024]
+main = hspec $ do
+    describe "FEC" $ do
+        it "does stuff" $ (withMaxSuccess 10000 prop_FEC)
+        it "can divide" $ mapM_ checkDivide [1, 2, 3, 4, 10]
+        it "can enFec" $ mapM_ checkEnFEC [1, 2, 3, 4, 5, 1024 * 1024]

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -8,9 +8,10 @@ import qualified Codec.FEC as FEC
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import Data.Int
-import Data.List (sortBy)
+import Data.List (sortOn)
 import Data.Serializer
 import Data.Word
+
 import System.IO (IOMode (..), withFile)
 import System.Random
 import Test.QuickCheck
@@ -41,7 +42,7 @@ instance Arbitrary FEC.FECParams where
 randomTake :: Int -> Int -> [a] -> [a]
 randomTake seed n values = map snd $ take n sortedValues
   where
-    sortedValues = sortBy (\a b -> compare (fst a) (fst b)) taggedValues
+    sortedValues = sortOn fst taggedValues
     taggedValues = zip rnds values
     rnds :: [Float]
     rnds = randoms gen

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -89,15 +89,18 @@ testFEC fec len seed = FEC.decode fec someTaggedBlocks == origBlocks
     -- secondary) to try to use for decoding.
     someTaggedBlocks = randomTake seed (FEC.paramK fec) taggedBlocks
 
+-- | @FEC.secureDivide@ is the inverse of @FEC.secureCombine@.
 prop_divide :: Word16 -> Word8 -> Word8 -> Property
 prop_divide size byte divisor = monadicIO $ do
   let input = B.replicate (fromIntegral size + 1) byte
   parts <- run $ FEC.secureDivide (fromIntegral divisor) input
   assert (FEC.secureCombine parts == input)
 
+-- | @FEC.encode@ is the inverse of @FEC.decode@.
 prop_decode :: FEC.FECParams -> Word16 -> Int -> Property
 prop_decode fec len seed = property $ testFEC fec len seed
 
+-- | @FEC.enFEC@ is the inverse of @FEC.deFEC@.
 prop_deFEC :: Params -> ArbByteString -> Property
 prop_deFEC (Params required total) (ArbByteString testdata) =
   FEC.deFEC required total minimalShares === testdataStrict

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -64,6 +64,6 @@ checkEnFEC len = do
 main :: IO ()
 main = hspec $ do
     describe "FEC" $ do
-        it "can divide" $ mapM_ checkDivide [1, 2, 3, 4, 10]
-        it "decode is the inverse of encode" $ (withMaxSuccess 5000 prop_FEC)
-        it "deFEC is the inverse of enFEC" $ mapM_ checkEnFEC [1, 2, 3, 4, 5, 1024 * 1024]
+        it "secureCombine is the inverse of secureDivide n" $ mapM_ checkDivide [1, 2, 3, 4, 10]
+        it "decode is (nearly) the inverse of encode" $ (withMaxSuccess 5000 prop_FEC)
+        it "deFEC is the inverse of enFEC" $ (withMaxSuccess 5000 prop_enFEC)

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -38,8 +38,8 @@ data Params = Params
 -- | A somewhat efficient generator for valid ZFEC parameters.
 instance Arbitrary Params where
     arbitrary = do
-        required <- choose (1, 256)
-        total <- choose (required, 256)
+        required <- choose (1, 255)
+        total <- choose (required, 255)
         return $ Params required total
 
 instance Arbitrary FEC.FECParams where
@@ -96,7 +96,7 @@ prop_divide size byte divisor = monadicIO $ do
   assert (FEC.secureCombine parts == input)
 
 prop_decode :: FEC.FECParams -> Word16 -> Int -> Property
-prop_decode fec len seed = len < 1024 ==> testFEC fec len seed
+prop_decode fec len seed = property $ testFEC fec len seed
 
 prop_deFEC :: Params -> ArbByteString -> Property
 prop_deFEC (Params required total) (ArbByteString testdata) =
@@ -122,4 +122,4 @@ main = hspec $ do
     describe "decode" $ do
         it "is (nearly) the inverse of encode" $ (withMaxSuccess 2000 prop_decode)
         it "works with total=256" $ property $ prop_decode (FEC.fec 1 256)
-        it "works with required=256" $ property $ prop_decode (FEC.fec 256 256)
+        it "works with required=255" $ property $ prop_decode (FEC.fec 255 256)

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -38,8 +38,8 @@ data Params = Params
 -- | A somewhat efficient generator for valid ZFEC parameters.
 instance Arbitrary Params where
     arbitrary = do
-        required <- choose (1, 254)
-        total <- choose (min 255 (required + 1), 255)
+        required <- choose (1, 256)
+        total <- choose (required, 256)
         return $ Params required total
 
 instance Arbitrary FEC.FECParams where

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -53,13 +53,8 @@ checkEnFEC len = do
         then return ()
         else fail "deFEC failure"
 
+main :: IO ()
 main = do
-    mapM_
-        (check (defaultConfig{configMaxTest = 1000, configMaxFail = 10000}))
-        [prop_FEC]
-        mapM_
-        checkDivide
-        [1, 2, 3, 4, 10]
-        mapM_
-        checkEnFEC
-        [1, 2, 3, 4, 5, 1024 * 1024]
+    mapM_ quickCheck [prop_FEC]
+    mapM_ checkDivide [1, 2, 3, 4, 10]
+    mapM_ checkEnFEC [1, 2, 3, 4, 5, 1024 * 1024]

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -115,5 +115,4 @@ main = hspec $ do
 
     describe "decode" $ do
         it "is (nearly) the inverse of encode" $ (withMaxSuccess 2000 prop_decode)
-        it "works with total=256" $ property $ prop_decode (FEC.fec 1 256)
-        it "works with required=255" $ property $ prop_decode (FEC.fec 255 256)
+        it "works with required=255" $ property $ prop_decode (FEC.fec 255 255)


### PR DESCRIPTION
This adjusts the input validation done by the Haskell bindings to allow n == k, which is supported by the C library and allowed by the Python bindings to that library.  Notably, Tahoe-LAFS also allows users to configure n == k so Tahoe-LAFS depends on this functionality.

This also comes with a rewrite of most of the test suite for the Haskell bindings to use QuickCheck and more thoroughly exercise the relevant code.

This also comes with a Nix flake that can build the package and provides a dev environment that includes build dependencies and other developer-oriented tools (notably haskell-language-server).

There is also a `.envrc` that automatically enables the Flake-supplied dev environment, for anyone who wants to use direnv.

This also includes an update of the cabal file because the version in the repository was not readable by a reasonable version of cabal that I could get my hands on (due to its age).
