### PR TITLE
Remove `unsafePerformIO`

### DIFF
--- a/fec.cabal
+++ b/fec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.4
 name:               fec
-version:            0.1.1
+version:            0.2.0
 license:            GPL-2.0-or-later
 license-file:       README.rst
 author:             Adam Langley <agl@imperialviolet.org>

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -106,11 +106,10 @@ prop_primary_copies (Params _ total) primary = monadicIO $ do
 
 -- | @FEC.enFEC@ is the inverse of @FEC.deFEC@.
 prop_deFEC :: Params -> B.ByteString -> Property
-prop_deFEC (Params required total) testdata =
-  FEC.deFEC required total minimalShares === testdata
-  where
-    allShares = FEC.enFEC required total testdata
-    minimalShares = take required allShares
+prop_deFEC (Params required total) testdata = monadicIO $ do
+  encoded <- run $ FEC.enFEC required total testdata
+  decoded <- run $ FEC.deFEC required total (take required encoded)
+  assert $ testdata == decoded
 
 main :: IO ()
 main = hspec $

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -4,6 +4,7 @@ module Main where
 
 import Test.Hspec
 
+import Control.Monad (replicateM_)
 import Control.Monad.IO.Class (
     liftIO,
  )
@@ -128,4 +129,9 @@ main = hspec $
             it "works with required=255" $ property $ prop_decode (Params 255 255)
 
         describe "encode" $ do
-            it "returns copies of the primary block for all 1 of N encodings" $ property $ withMaxSuccess 10000 prop_primary_copies
+            -- Since a single property won't result in parallel execution, add a
+            -- few of these.
+            replicateM_ 10 $
+                it "returns copies of the primary block for all 1 of N encodings" $
+                    property $
+                        withMaxSuccess 10000 prop_primary_copies

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -98,11 +98,11 @@ prop_decode (Params required total) len seed =
         fec <- FEC.fec required total
         testFEC fec len seed
 
-prop_primary_copies :: Params -> ArbByteString -> Property
-prop_primary_copies (Params _ total) (ArbByteString primary) = monadicIO $ do
+prop_primary_copies :: Params -> B.ByteString -> Property
+prop_primary_copies (Params _ total) primary = monadicIO $ do
     fec <- run $ FEC.fec 1 total
-    secondary <- run $ FEC.encode fec [BL.toStrict primary]
-    assert $ all (BL.toStrict primary ==) secondary
+    secondary <- run $ FEC.encode fec [primary]
+    assert $ all (primary ==) secondary
 
 -- | @FEC.enFEC@ is the inverse of @FEC.deFEC@.
 prop_deFEC :: Params -> B.ByteString -> Property

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -5,25 +5,29 @@ module Main where
 
 import Test.Hspec
 
-import Data.Word
-import qualified Data.ByteString.Lazy as BL
+import Control.Monad.IO.Class (
+    liftIO,
+ )
+
 import qualified Codec.FEC as FEC
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
+import Data.Int
 import Data.List (sortBy)
+import Data.Serializer
+import Data.Word
 import System.IO (IOMode (..), withFile)
 import System.Random
-import Data.Int
-import Data.Serializer
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
 
 newtype ArbByteString = ArbByteString BL.ByteString deriving newtype (Show, Ord, Eq)
 
 instance Arbitrary ArbByteString where
-  arbitrary = do
-    len <- choose (0, 1024 * 64) :: Gen Int32
-    -- Invent some bytes that are somewhat distinctive-ish.
-    return . ArbByteString $ expand len (toLazyByteString len)
+    arbitrary = do
+        len <- choose (0, 1024 * 64) :: Gen Int32
+        -- Invent some bytes that are somewhat distinctive-ish.
+        return . ArbByteString $ expand len (toLazyByteString len)
 
 expand :: Integral i => i -> BL.ByteString -> BL.ByteString
 expand len = BL.take (fromIntegral len) . BL.cycle
@@ -42,11 +46,6 @@ instance Arbitrary Params where
         total <- choose (required, 255)
         return $ Params required total
 
-instance Arbitrary FEC.FECParams where
-    arbitrary = do
-      (Params required total) <- arbitrary :: Gen Params
-      return $ FEC.fec required total
-
 randomTake :: Int -> Int -> [a] -> [a]
 randomTake seed n values = map snd $ take n sortedValues
   where
@@ -56,73 +55,88 @@ randomTake seed n values = map snd $ take n sortedValues
     rnds = randoms gen
     gen = mkStdGen seed
 
--- | Any combination of the inputs blocks and the output blocks from
--- @FEC.encode@, as long as there are at least @k@ of them, can be recombined
--- using @FEC.decode@ to produce the original input blocks.
---
-testFEC
-  :: FEC.FECParams
-  -- ^ The FEC parameters to exercise.
-  -> Word16
-  -- ^ The length of the blocks to exercise.
-  -> Int
-  -- ^ A random seed to use to be able to vary the choice of which blocks to
-  -- try to decode.
-  -> Bool
-  -- ^ True if the encoded input was reconstructed by decoding, False
-  -- otherwise.
-testFEC fec len seed = FEC.decode fec someTaggedBlocks == origBlocks
-  where
-    -- Construct some blocks.  Each will just be the byte corresponding to the
-    -- block number repeated to satisfy the requested length.
-    origBlocks = B.replicate (fromIntegral len) . fromIntegral <$> [0 .. (FEC.paramK fec - 1)]
+{- | Any combination of the inputs blocks and the output blocks from
+ @FEC.encode@, as long as there are at least @k@ of them, can be recombined
+ using @FEC.decode@ to produce the original input blocks.
+-}
+testFEC ::
+    -- | The FEC parameters to exercise.
+    FEC.FECParams ->
+    -- | The length of the blocks to exercise.
+    Word16 ->
+    -- | A random seed to use to be able to vary the choice of which blocks to
+    -- try to decode.
+    Int ->
+    -- | True if the encoded input was reconstructed by decoding, False
+    -- otherwise.
+    Expectation
+testFEC fec len seed =
+    let -- Construct some blocks.  Each will just be the byte corresponding to the
+        -- block number repeated to satisfy the requested length.
+        origBlocks = B.replicate (fromIntegral len) . fromIntegral <$> [0 .. (FEC.paramK fec - 1)]
+     in do
+            -- Encode the data to produce the "secondary" blocks which (might) add
+            -- redundancy to the original blocks.
+            secondaryBlocks <- FEC.encode fec origBlocks
 
-    -- Encode the data to produce the "secondary" blocks which (might) add
-    -- redundancy to the original blocks.
-    secondaryBlocks = FEC.encode fec origBlocks
+            let -- Tag each block with its block number because the decode API requires
+                -- this information.
+                taggedBlocks = zip [0 ..] (origBlocks ++ secondaryBlocks)
 
-    -- Tag each block with its block number because the decode API requires
-    -- this information.
-    taggedBlocks = zip [0 ..] (origBlocks ++ secondaryBlocks)
+                -- Choose enough of the tagged blocks (some combination of original and
+                -- secondary) to try to use for decoding.
+                someTaggedBlocks = randomTake seed (FEC.paramK fec) taggedBlocks
 
-    -- Choose enough of the tagged blocks (some combination of original and
-    -- secondary) to try to use for decoding.
-    someTaggedBlocks = randomTake seed (FEC.paramK fec) taggedBlocks
+            decoded <- FEC.decode fec someTaggedBlocks
+            decoded `shouldBe` origBlocks
 
 -- | @FEC.secureDivide@ is the inverse of @FEC.secureCombine@.
 prop_divide :: Word16 -> Word8 -> Word8 -> Property
 prop_divide size byte divisor = monadicIO $ do
-  let input = B.replicate (fromIntegral size + 1) byte
-  parts <- run $ FEC.secureDivide (fromIntegral divisor) input
-  assert (FEC.secureCombine parts == input)
+    let input = B.replicate (fromIntegral size + 1) byte
+    parts <- run $ FEC.secureDivide (fromIntegral divisor) input
+    assert (FEC.secureCombine parts == input)
 
 -- | @FEC.encode@ is the inverse of @FEC.decode@.
-prop_decode :: FEC.FECParams -> Word16 -> Int -> Property
-prop_decode fec len seed = property $ testFEC fec len seed
+prop_decode :: Params -> Word16 -> Int -> Property
+prop_decode (Params required total) len seed =
+    monadicIO . run $ do
+        fec <- FEC.fec required total
+        testFEC fec len seed
 
 -- | @FEC.enFEC@ is the inverse of @FEC.deFEC@.
 prop_deFEC :: Params -> ArbByteString -> Property
-prop_deFEC (Params required total) (ArbByteString testdata) =
-  FEC.deFEC required total minimalShares === testdataStrict
-  where
-    allShares = FEC.enFEC required total testdataStrict
-    minimalShares = take required allShares
-    testdataStrict = BL.toStrict testdata
+prop_deFEC (Params required total) (ArbByteString testdata) = monadicIO $ do
+    let testdataStrict = BL.toStrict testdata
+    allShares <- run $ FEC.enFEC required total testdataStrict
+    let minimalShares = take required allShares
+    decoded <- run $ FEC.deFEC required total minimalShares
+    assert $ decoded == testdataStrict
+
+prop_primary_copies :: Params -> ArbByteString -> Property
+prop_primary_copies (Params _ total) (ArbByteString primary) = monadicIO $ do
+    fec <- run $ FEC.fec 1 total
+    secondary <- run $ FEC.encode fec [BL.toStrict primary]
+    assert $ all (BL.toStrict primary ==) secondary
 
 main :: IO ()
-main = hspec $ do
-    describe "secureCombine" $ do
-        -- secureDivide is insanely slow and memory hungry for large inputs,
-        -- like QuickCheck will find with it as currently defined.  Just pass
-        -- some small inputs.  It's not clear it's worth fixing (or even
-        -- keeping) thesefunctions.  They don't seem to be used by anything.
-        -- Why are they here?
-        it "is the inverse of secureDivide n" $ once $ prop_divide 1024 65 3
+main = hspec $
+    parallel $ do
+        describe "secureCombine" $ do
+            -- secureDivide is insanely slow and memory hungry for large inputs,
+            -- like QuickCheck will find with it as currently defined.  Just pass
+            -- some small inputs.  It's not clear it's worth fixing (or even
+            -- keeping) thesefunctions.  They don't seem to be used by anything.
+            -- Why are they here?
+            it "is the inverse of secureDivide n" $ once $ prop_divide 1024 65 3
 
-    describe "deFEC" $ do
-        it "is the inverse of enFEC" $ (withMaxSuccess 2000 prop_deFEC)
+        -- describe "deFEC" $ do
+        --     it "is the inverse of enFEC" $ (withMaxSuccess 2000 prop_deFEC)
 
-    describe "decode" $ do
-        it "is (nearly) the inverse of encode" $ (withMaxSuccess 2000 prop_decode)
-        it "works with total=256" $ property $ prop_decode (FEC.fec 1 256)
-        it "works with required=255" $ property $ prop_decode (FEC.fec 255 256)
+        -- describe "decode" $ do
+        --     it "is (nearly) the inverse of encode" $ withMaxSuccess 2000 prop_decode
+        --     it "works with total=255" $ property $ prop_decode (Params 1 255)
+        --     it "works with required=255" $ property $ prop_decode (Params 255 255)
+
+        describe "encode" $ do
+            it "returns copies of the primary block for all 1 of N encodings" $ property $ withMaxSuccess 10000 prop_primary_copies

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -120,7 +120,7 @@ main = hspec $
             it "is the inverse of secureDivide n" $ once $ prop_divide 1024 65 3
 
         describe "deFEC" $ do
-            it "is the inverse of enFEC" $ (withMaxSuccess 2000 prop_deFEC)
+            it "is the inverse of enFEC" $ withMaxSuccess 2000 prop_deFEC
 
         describe "decode" $ do
             it "is (nearly) the inverse of encode" $ withMaxSuccess 2000 prop_decode

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -12,9 +12,6 @@ import qualified Codec.FEC as FEC
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import Data.Int
-import Data.List (sortBy)
-import Data.Serializer
-import Data.Word
 import Data.List (sortOn)
 import Data.Serializer
 import Data.Word
@@ -107,9 +104,9 @@ prop_primary_copies (Params _ total) primary = monadicIO $ do
 -- | @FEC.enFEC@ is the inverse of @FEC.deFEC@.
 prop_deFEC :: Params -> B.ByteString -> Property
 prop_deFEC (Params required total) testdata = monadicIO $ do
-  encoded <- run $ FEC.enFEC required total testdata
-  decoded <- run $ FEC.deFEC required total (take required encoded)
-  assert $ testdata == decoded
+    encoded <- run $ FEC.enFEC required total testdata
+    decoded <- run $ FEC.deFEC required total (take required encoded)
+    assert $ testdata == decoded
 
 main :: IO ()
 main = hspec $

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -61,25 +61,25 @@ testFEC ::
     -- | True if the encoded input was reconstructed by decoding, False
     -- otherwise.
     Expectation
-testFEC fec len seed =
-    let -- Construct some blocks.  Each will just be the byte corresponding to the
-        -- block number repeated to satisfy the requested length.
-        origBlocks = B.replicate (fromIntegral len) . fromIntegral <$> [0 .. (FEC.paramK fec - 1)]
-     in do
-            -- Encode the data to produce the "secondary" blocks which (might) add
-            -- redundancy to the original blocks.
-            secondaryBlocks <- FEC.encode fec origBlocks
+testFEC fec len seed = do
+    -- Encode the data to produce the "secondary" blocks which (might) add
+    -- redundancy to the original blocks.
+    secondaryBlocks <- FEC.encode fec origBlocks
 
-            let -- Tag each block with its block number because the decode API requires
-                -- this information.
-                taggedBlocks = zip [0 ..] (origBlocks ++ secondaryBlocks)
+    let -- Tag each block with its block number because the decode API requires
+        -- this information.
+        taggedBlocks = zip [0 ..] (origBlocks ++ secondaryBlocks)
 
-                -- Choose enough of the tagged blocks (some combination of original and
-                -- secondary) to try to use for decoding.
-                someTaggedBlocks = randomTake seed (FEC.paramK fec) taggedBlocks
+        -- Choose enough of the tagged blocks (some combination of original and
+        -- secondary) to try to use for decoding.
+        someTaggedBlocks = randomTake seed (FEC.paramK fec) taggedBlocks
 
-            decoded <- FEC.decode fec someTaggedBlocks
-            decoded `shouldBe` origBlocks
+    decoded <- FEC.decode fec someTaggedBlocks
+    decoded `shouldBe` origBlocks
+  where
+    -- Construct some blocks.  Each will just be the byte corresponding to the
+    -- block number repeated to satisfy the requested length.
+    origBlocks = B.replicate (fromIntegral len) . fromIntegral <$> [0 .. (FEC.paramK fec - 1)]
 
 -- | @FEC.secureDivide@ is the inverse of @FEC.secureCombine@.
 prop_divide :: Word16 -> Word8 -> Word8 -> Property


### PR DESCRIPTION
It's not clear that these uses are safe and it doesn't seem like much of a hardship to just drop them and force the caller to operate in `IO`.
