### PR TITLE
Replace QuickCheck with Hedgehog

### DIFF
--- a/fec.cabal
+++ b/fec.cabal
@@ -51,9 +51,9 @@ test-suite tests
     , bytestring
     , data-serializer
     , fec
-    , hspec
-    , QuickCheck
-    , quickcheck-instances
+    , hedgehog
     , random
+    , tasty
+    , tasty-hedgehog
 
   default-language: Haskell2010


### PR DESCRIPTION
Tasty / Hedgehog runner has some better command line options for controlling how the suite runs.  Also the tests end up being a bit more succinct.

I also hoped this would reveal the same misbehavior as tahoe-chk sees when its Hedgehog-based tests exercise Codec.FEC.encode/decode but alas this has not happened.