### PR TITLE
Require explicit, single-threaded initialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: "nix build"
           no_output_timeout: "30m"
           command: |
-            nix build -v
+            nix build --print-build-logs
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
       - run:
           name: "Nix Build"
-          no_output_timeout: "30m"
+          no_output_timeout: "90m"
           command: |
             nix build --print-build-logs
 

--- a/fec.cabal
+++ b/fec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               fec
-version:            0.1.1
+version:            0.2.0
 license:            GPL-2.0-or-later
 license-file:       README.rst
 author:             Adam Langley <agl@imperialviolet.org>
@@ -31,6 +31,7 @@ library
   build-depends:
     , base
     , bytestring  >=0.9
+    , extra
 
   exposed-modules:    Codec.FEC
   default-extensions: ForeignFunctionInterface

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -112,8 +112,10 @@ prop_primary_copies (Params _ tot) primary = property $ do
     secondary = FEC.encode fec [BL.toStrict primary]
 
 main :: IO ()
-main = hspec $
-    parallel $ do
+main = do
+    -- Be sure to do the required zfec initialization first.
+    FEC.initialize
+    hspec . parallel $ do
         describe "encode" $ do
             -- This test originally caught a bug in multi-threaded
             -- initialization of the C library.  Since it is in the

--- a/haskell/test/FECTest.hs
+++ b/haskell/test/FECTest.hs
@@ -132,8 +132,7 @@ main = do
             -- by this property sometimes.
             replicateM_ 20 $
                 it "returns copies of the primary block for all 1 of N encodings" $
-                    property $
-                        withMaxSuccess 50 prop_primary_copies
+                    withMaxSuccess 5 prop_primary_copies
 
         describe "secureCombine" $ do
             -- secureDivide is insanely slow and memory hungry for large inputs,
@@ -145,9 +144,10 @@ main = do
 
         describe "deFEC" $ do
             replicateM_ 10 $
-                it "is the inverse of enFEC" (withMaxSuccess 200 prop_deFEC)
+                it "is the inverse of enFEC" $
+                    property prop_deFEC
 
         describe "decode" $
             replicateM_ 10 $ do
-                it "is (nearly) the inverse of encode" (withMaxSuccess 200 prop_decode)
+                it "is (nearly) the inverse of encode" $ property $ prop_decode
                 it "works with required=255" $ property $ prop_decode (Params 255 255)

--- a/zfec/_fecmodule.c
+++ b/zfec/_fecmodule.c
@@ -673,6 +673,8 @@ init_fec(void) {
     py_fec_error = PyErr_NewException("_fec.Error", NULL, NULL);
     PyDict_SetItemString(module_dict, "Error", py_fec_error);
 
+    fec_init();
+
 #if PY_MAJOR_VERSION >= 3
     return module;
 #endif

--- a/zfec/fec.c
+++ b/zfec/fec.c
@@ -393,6 +393,14 @@ _invert_vdm (gf* src, unsigned k) {
     return;
 }
 
+/* There are few (if any) ordering guarantees that apply to reads and writes
+ * of this static int across threads.  This is the reason for some of the
+ * tight requirements for how `fec_init` is called.  If we could use a mutex
+ * or a C11 atomic here we might be able to provide more flexibility to
+ * callers.  It's tricky to do that while remaining compatible with all of
+ * macOS/Linux/Windows and CPython's MSVC requirements and not switching to
+ * C++ (or something even more different).
+ */
 static int fec_initialized = 0;
 
 void

--- a/zfec/fec.c
+++ b/zfec/fec.c
@@ -394,11 +394,14 @@ _invert_vdm (gf* src, unsigned k) {
 }
 
 static int fec_initialized = 0;
-static void
-init_fec (void) {
-    generate_gf();
-    _init_mul_table();
-    fec_initialized = 1;
+
+void
+fec_init (void) {
+    if (fec_initialized == 0) {
+        generate_gf();
+        _init_mul_table();
+        fec_initialized = 1;
+    }
 }
 
 /*
@@ -428,8 +431,9 @@ fec_new(unsigned short k, unsigned short n) {
     assert(n <= 256);
     assert(k <= n);
 
-    if (fec_initialized == 0)
-        init_fec ();
+    if (fec_initialized == 0) {
+        return NULL;
+    }
 
     retval = (fec_t *) malloc (sizeof (fec_t));
     retval->k = k;

--- a/zfec/fec.h
+++ b/zfec/fec.h
@@ -20,6 +20,14 @@ typedef struct {
 #define restrict
 #endif
 
+/** Initialize the fec library.
+ *
+ * Call this at least one time from at most one thread to initialize the
+ * library's internal state.  Call this before calling any other APIs from the
+ * library.
+ */
+void fec_init(void);
+
 /**
  * param k the number of blocks required to reconstruct
  * param m the total number of blocks created

--- a/zfec/fec.h
+++ b/zfec/fec.h
@@ -22,9 +22,13 @@ typedef struct {
 
 /** Initialize the fec library.
  *
- * Call this at least one time from at most one thread to initialize the
- * library's internal state.  Call this before calling any other APIs from the
- * library.
+ * Call this:
+ *
+ *  - at least once
+ *  - from at most one thread at a time
+ *  - before calling any other APIs from the library
+ *  - before creating any other threads that will use APIs from the library
+ *
  */
 void fec_init(void);
 


### PR DESCRIPTION
Fixes #89 

This changes the underlying C library to *require* an initial call to `fec_init` before `fec_new` (and therefore the other APIs) can succeed.  This avoids the problem where multiple threads call `fec_new` and implicitly trigger parallel initialization leading to corruption of some zfec internal state.

Calls to the C function `fec_new` will now return NULL if a call to the C function `fec_init` has not yet completed.

This change is not visible to the Python bindings because (a) they always call into fec while holding the GIL and so there is no chance for multithreaded usage and (b) the Python module initializer in the bindings now calls the initialization function automatically.

This change _is_ visible to the Haskell bindings because the Haskell API can really make parallel calls into the fec library from multiple OS threads.  Therefore, there is a new Haskell API, `Codec.FEC.initialize`, which must be used before `Codec.FEC.new`.  If it is not, `Codec.FEC.new` will throw an exception.

This is an incompatible change to the Haskell API so it comes with a version bump for those bindings.
