### PR TITLE
Run the tests with more prompt output on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,26 @@
 version: "2.1"
 
 jobs:
+  cabal-test:
+    docker:
+      - image: "nixos/nix:2.13.2"
+
+    environment:
+      # Let us use features marked "experimental".  For example, most/all of
+      # the `nix <subcommand>` forms.  Also, allow import from derivation
+      # because cabal2nix requires it.
+      NIX_CONFIG: |
+        experimental-features = nix-command flakes
+        allow-import-from-derivation = true
+
+    steps:
+      - "checkout"
+      - run:
+          name: "Haskell Test Suite"
+          no_output_timeout: "30m"
+          command: |
+            nix run .#cabal-test
+
   nix-build:
     docker:
       - image: "nixos/nix:2.13.2"
@@ -22,12 +42,13 @@ jobs:
             nix flake check -v
 
       - run:
-          name: "Haskell Test Suite"
+          name: "Nix Build"
           no_output_timeout: "30m"
           command: |
-            nix run .#cabal-test
+            nix build --print-build-logs
 
 workflows:
   ci:
     jobs:
-      - nix-build
+      - "cabal-test"
+      - "nix-build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
             nix flake check -v
 
       - run:
-          name: "nix build"
+          name: "Haskell Test Suite"
           no_output_timeout: "30m"
           command: |
-            nix build -v
+            nix run .#cabal-test
 
 workflows:
   ci:

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1673454489,
-        "narHash": "sha256-LsOintvQ4n3QPkI5MA+IhmlLlH5BVzL2xqT/h5U5K7w=",
+        "lastModified": 1692187439,
+        "narHash": "sha256-m7c4EPFWmB1OmV3dSYQk2qtXR53xOjZdLCjMtzHSK34=",
         "ref": "main",
-        "rev": "4feccf13501960b92e1d9d73bf6e046b36861af0",
-        "revCount": 4,
+        "rev": "408f3deab2e2f6ae60349776dde02c44f71fb386",
+        "revCount": 16,
         "type": "git",
         "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
       },
@@ -109,16 +109,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1671271954,
-        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -138,11 +138,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1673281605,
-        "narHash": "sha256-v6U0G3pJe0YaIuD1Ijhz86EhTgbXZ4f/2By8sLqFk4c=",
+        "lastModified": 1677722096,
+        "narHash": "sha256-7mjVMvCs9InnrRybBfr5ohqcOz+pyEX8m22C1XsDilg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f8992fb404c7e79638192a10905b7ea985818050",
+        "rev": "61a3511668891c68ebd19d40122150b98dc2fe3b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1692187439,
-        "narHash": "sha256-m7c4EPFWmB1OmV3dSYQk2qtXR53xOjZdLCjMtzHSK34=",
+        "lastModified": 1695048281,
+        "narHash": "sha256-zkXDTX2aM6mOiYZlc60NJTAb3mrDrrlNN7lHE3GSvhk=",
         "ref": "main",
-        "rev": "408f3deab2e2f6ae60349776dde02c44f71fb386",
-        "revCount": 16,
+        "rev": "628ffddf1a6c59036fa1a4b76daddb9b34065e04",
+        "revCount": 17,
         "type": "git",
         "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -32,9 +32,10 @@
         hlint = hslib.apps.hlint {argv = ["haskell/"];};
         cabal-test = hslib.apps.cabal-test {
           extraRuntimeInputs = pkgs: [
-            # A build-time dependency of old-time, a transitive dependency of
-            # ours...
+            # Some build-time dependencies of old-time, a transitive
+            # dependency of ours...
             pkgs.gnused
+            pkgs.gawk
           ];
           preBuild = ''
             cabal update hackage.haskell.org

--- a/flake.nix
+++ b/flake.nix
@@ -28,5 +28,9 @@
       checks = hslib.checks {};
       devShells = hslib.devShells {};
       packages = hslib.packages {};
+      apps = {
+        hlint = hslib.apps.hlint {argv = ["haskell/"];};
+        cabal-test = hslib.apps.cabal-test {testTargetName = "test:tests";};
+      };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,14 @@
       packages = hslib.packages {};
       apps = {
         hlint = hslib.apps.hlint {argv = ["haskell/"];};
-        cabal-test = hslib.apps.cabal-test {testTargetName = "test:tests";};
+        cabal-test = hslib.apps.cabal-test {
+          preBuild = ''
+            cabal get old-time-1.1.0.3
+            cd old-time-1.1.0.3
+            cabal build
+          '';
+          testTargetName = "test:tests";
+        };
       };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
         hlint = hslib.apps.hlint {argv = ["haskell/"];};
         cabal-test = hslib.apps.cabal-test {
           preBuild = ''
+            cabal update hackage.haskell.org
             cabal get old-time-1.1.0.3
             cd old-time-1.1.0.3
             cabal build

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,11 @@
       apps = {
         hlint = hslib.apps.hlint {argv = ["haskell/"];};
         cabal-test = hslib.apps.cabal-test {
+          extraRuntimeInputs = pkgs: [
+            # A build-time dependency of old-time, a transitive dependency of
+            # ours...
+            pkgs.gnused
+          ];
           preBuild = ''
             cabal update hackage.haskell.org
             cabal get old-time-1.1.0.3

--- a/flake.nix
+++ b/flake.nix
@@ -37,12 +37,6 @@
             pkgs.gnused
             pkgs.gawk
           ];
-          preBuild = ''
-            cabal update hackage.haskell.org
-            cabal get old-time-1.1.0.3
-            cd old-time-1.1.0.3
-            cabal build
-          '';
           testTargetName = "test:tests";
         };
       };


### PR DESCRIPTION
`nix build` runs the tests with `cabal test` which eats the test suite except on failure.  This seems to lead to CircleCI hitting an idle timeout and killing the job.

Now run the suite with `cabal run test:tests` which streams test suite output and hopefully fixes this problem.
