### PR TITLE
Allow control over how the encoding matrix is built

### DIFF
--- a/zfec/__init__.py
+++ b/zfec/__init__.py
@@ -9,6 +9,9 @@ zfec web site: U{http://tahoe-lafs.org/source/zfec}
 from . import _version
 __version__ = _version.get_versions()['version']
 
+OPTION_POWER_SEQUENCE = 0
+OPTION_SEQUENTIAL_INTEGERS = 1
+
 from ._fec import Encoder, Decoder, Error
 from . import easyfec, filefec, cmdline_zfec, cmdline_zunfec
 

--- a/zfec/_fecmodule.c
+++ b/zfec/_fecmodule.c
@@ -73,10 +73,11 @@ Encoder_init(Encoder *self, PyObject *args, PyObject *kwdict) {
     static char *kwlist[] = {
         "k",
         "m",
+        "option",
         NULL
     };
-    int ink, inm;
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "ii:Encoder.__init__", kwlist, &ink, &inm))
+    int ink, inm, option = FEC_OPTION_POWER_SEQUENCE;
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "ii|i:Encoder.__init__", kwlist, &ink, &inm, &option))
         return -1;
 
     if (ink < 1) {
@@ -95,11 +96,15 @@ Encoder_init(Encoder *self, PyObject *args, PyObject *kwdict) {
         PyErr_Format(py_fec_error, "Precondition violation: first argument is required to be less than or equal to the second argument, but they were %d and %d respectively", ink, inm);
         return -1;
     }
+    if (option != FEC_OPTION_POWER_SEQUENCE && option != FEC_OPTION_SEQUENTIAL_INTEGERS) {
+        PyErr_Format(py_fec_error, "Precondition violation: option third argument must be one of (%d,%d)", FEC_OPTION_POWER_SEQUENCE, FEC_OPTION_SEQUENTIAL_INTEGERS);
+        return -1;
+    }
     self->kk = (unsigned short)ink;
     self->mm = (unsigned short)inm;
 
     Py_BEGIN_ALLOW_THREADS
-    self->fec_matrix = fec_new(self->kk, self->mm);
+    self->fec_matrix = fec_new2(self->kk, self->mm, option);
     Py_END_ALLOW_THREADS
 
     return 0;
@@ -340,11 +345,12 @@ Decoder_init(Encoder *self, PyObject *args, PyObject *kwdict) {
     static char *kwlist[] = {
         "k",
         "m",
+        "option",
         NULL
     };
 
-    int ink, inm;
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "ii:Decoder.__init__", kwlist, &ink, &inm))
+    int ink, inm, option = FEC_OPTION_POWER_SEQUENCE;
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "ii|i:Decoder.__init__", kwlist, &ink, &inm, &option))
         return -1;
 
     if (ink < 1) {
@@ -367,7 +373,7 @@ Decoder_init(Encoder *self, PyObject *args, PyObject *kwdict) {
     self->mm = (unsigned short)inm;
 
     Py_BEGIN_ALLOW_THREADS
-    self->fec_matrix = fec_new(self->kk, self->mm);
+    self->fec_matrix = fec_new2(self->kk, self->mm, option);
     Py_END_ALLOW_THREADS
 
     return 0;

--- a/zfec/easyfec.py
+++ b/zfec/easyfec.py
@@ -22,8 +22,8 @@ def ab(x): # debuggery
         return "%s:%s" % (len(x), "--empty--",)
 
 class Encoder(object):
-    def __init__(self, k, m):
-        self.fec = zfec.Encoder(k, m)
+    def __init__(self, k, m, option=0):
+        self.fec = zfec.Encoder(k, m, option=option)
 
     def encode(self, data):
         """
@@ -39,8 +39,8 @@ class Encoder(object):
         return self.fec.encode(l)
         
 class Decoder(object):
-    def __init__(self, k, m):
-        self.fec = zfec.Decoder(k, m)
+    def __init__(self, k, m, option=0):
+        self.fec = zfec.Decoder(k, m, option=option)
 
     def decode(self, blocks, sharenums, padlen):
         """

--- a/zfec/fec.h
+++ b/zfec/fec.h
@@ -8,6 +8,25 @@
 
 typedef unsigned char gf;
 
+typedef enum {
+  /**
+   * This is the default option if you do not specify one.
+   * This instanciates the vandermonde matrix over a vector of
+   * powers of the primitive element. It ensures maximum 
+   * separation between elements in the field, which enhances
+   * error correction performance.
+   */
+  FEC_OPTION_POWER_SEQUENCE = 0,
+  /**
+   * This instanciates the vandermonde matrix over a vector of
+   * sequential integers. This choice is common among libraries
+   * that implement reed solomon erasure coding.
+   * Known libraries that do this:
+   *  - klauspost/reedsolomon
+   */
+  FEC_OPTION_SEQUENTIAL_INTEGERS = 1,
+} fec_option_t;
+
 typedef struct {
   unsigned long magic;
   unsigned short k, n;                     /* parameters of the code */
@@ -37,6 +56,12 @@ void fec_init(void);
  * param m the total number of blocks created
  */
 fec_t* fec_new(unsigned short k, unsigned short m);
+/**
+ * param k the number of blocks required to reconstruct
+ * param m the total number of blocks created
+ * param option options that control how the encoding/decoding matrix is built.
+ */
+fec_t* fec_new2(unsigned short k, unsigned short m, fec_option_t option);
 void fec_free(fec_t* p);
 
 /**


### PR DESCRIPTION
Allow users to pick an encoding matrix that is compatible with the klauspost/reedsolomon library.

The zfec library uses a vector of alpha^i to create its encoding matrix from the vandermonde matrix:
![Screenshot 2024-06-18 at 06-38-02 FEC-rizzo pdf](https://github.com/tahoe-lafs/zfec/assets/150022257/79b3a252-dea5-46bd-95b4-b12e5af345e5)


Some libraries use another common convention where the encoding matrix is built from the vandermonde matrix from a vector of sequential integers (0, 1, 2, 3, ...). The objective of this patch is to allow zfec to generate and consume data using this convention.