### PR TITLE
Don't build benchmarks by default

### DIFF
--- a/fec.cabal
+++ b/fec.cabal
@@ -45,7 +45,8 @@ library
   cc-options:         -std=c99
   include-dirs:       zfec
 
-executable benchmark-zfec
+Benchmark benchmark-zfec
+  type:             exitcode-stdio-1.0
   main-is:          Main.hs
   ghc-options:      -threaded
   build-depends:


### PR DESCRIPTION
Building the benchmark suite by default broke the tahoe-lafs-mobile build since its criterion can't be built with the android version of GHC.

Use `cabal build --enable-benchmark` to build the benchmark from now on.