### PR TITLE
Update macos for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       # Python versions in sync with the ones in test.yml.
       matrix:
         os:
-          - "macos-12"
+          - "macos-latest"
           - "ubuntu-22.04"
           - "windows-2022"
         wheel-selector:


### PR DESCRIPTION
Use "-latest" instead of "-13" since that's what itamar put in for our tests in 063cdd7f804f34f1a688984b63a739eeb3615a3a and a comment in build.yml says

> NOTE: when updating the matrix below, be sure to keep OS and
> Python versions in sync with the ones in test.yml.

----

Fixes #123.