### PR TITLE
Use trusted publishing with both PyPI and TestPyPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,12 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
+    name: Publish zfec on PyPI
+
+    # Publish to PyPI on release tag pushes.
+    if: >-
+      github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/zfec-')
+
     needs:
       - "build_wheels"
       - "build_sdist"
@@ -122,6 +128,53 @@ jobs:
     # GitHub web interface.
     environment:
       name: "release"
+      url: https://pypi.org/project/zfec/
+
+    # This permission is mandatory for trusted publishing
+    permissions:
+      id-token: write
+
+    steps:
+      # Download all artifacts previously built by this workflow to the dist
+      # directory where the publish step can find them.  These are the sdist
+      # and all of the wheels build by the other jobs.
+      - uses: "actions/download-artifact@v4"
+        with:
+          pattern: "*"
+          path: "dist"
+          merge-multiple: true
+
+      # Now define a conditional step to upload packages to the production
+      # instance of PyPI.
+      #
+      # The cases to consider are the same as for the upload to the testing
+      # instance.  This time, we have a conditional that runs only for case
+      # (2).
+      - name: "Publish to LIVE PyPI"
+        uses: "pypa/gh-action-pypi-publish@v1.6.4"
+        if: >-
+          github.event_name == 'push' &&
+          startsWith(github.event.ref, 'refs/tags/zfec-')
+
+  upload_testpypi:
+    name: Publish zfec on TestPyPI
+
+    # Publish to TestPyPI on pull requests. 
+    if: github.event_name == 'pull_request'
+
+    needs:
+      - "build_wheels"
+      - "build_sdist"
+
+    # It only needs to run once.  It will fetch all of the other build
+    # artifacts created by the other jobs and then upload them.
+    runs-on: "ubuntu-latest"
+
+    # Select the GitHub Actions environment that contains the PyPI tokens
+    # necessary to perform uploads.  This was configured manually using the
+    # GitHub web interface.
+    environment:
+      name: "testpypi"
       url: https://test.pypi.org/project/zfec/
 
     # This permission is mandatory for trusted publishing
@@ -149,23 +202,9 @@ jobs:
       # The conditional in this step should cause it to run only for case (3).
       - name: "Publish to TEST PyPI"
         uses: "pypa/gh-action-pypi-publish@v1.6.4"
-        if: >-
-          github.event_name == 'pull_request'
         with:
           # Override the default in order to upload it to the testing
           # deployment.
           repository-url: https://test.pypi.org/legacy/
           # please computer
           verbose: true
-
-      # Now define a conditional step to upload packages to the production
-      # instance of PyPI.
-      #
-      # The cases to consider are the same as for the upload to the testing
-      # instance.  This time, we have a conditional that runs only for case
-      # (2).
-      - name: "Publish to LIVE PyPI"
-        uses: "pypa/gh-action-pypi-publish@v1.6.4"
-        if: >-
-          github.event_name == 'push' &&
-          startsWith(github.event.ref, 'refs/tags/zfec-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,8 @@ jobs:
         uses: "pypa/gh-action-pypi-publish@v1.6.4"
         if: >-
           github.event_name == 'pull_request'
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
       # Now define a conditional step to upload packages to the production
       # instance of PyPI.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,10 @@ jobs:
     # GitHub web interface.
     environment: "release"
 
+    # This permission is mandatory for trusted publishing
+    permissions:
+      id-token: write
+
     steps:
       # Download all artifacts previously built by this workflow to the dist
       # directory where the publish step can find them.  These are the sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
-# Build sdist+wheel packages using GitHub Actions.  Mostly adopted
-# from https://cibuildwheel.readthedocs.io/en/stable/setup/
+# Build sdist+wheel packages using GitHub Actions, and publish them on
+# TestPyPI (on pull requests and tags) and PyPI (on tags).
+#
+# The build_wheels job is mostly adopted from
+# https://cibuildwheel.readthedocs.io/en/stable/setup/
+#
+# The upload_pypi and upload_testpypi jobs are adopted from Python
+# Packaging User Guide.
 
 name: "Packages"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
     # GitHub web interface.
     environment:
       name: "release"
-      url: https://pypi.org/project/zfec/
+      url: https://test.pypi.org/project/zfec/
 
     # This permission is mandatory for trusted publishing
     permissions:
@@ -155,8 +155,6 @@ jobs:
           # Override the default in order to upload it to the testing
           # deployment.
           repository-url: https://test.pypi.org/legacy/
-          # Do we need a different URL, or a whole new environment?
-          url: https://test.pypi.org/project/zfec/
           # please computer
           verbose: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
     # GitHub web interface.
     environment:
       name: "release"
+      url: https://pypi.org/project/zfec/
 
     # This permission is mandatory for trusted publishing
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,8 @@ jobs:
 
     # Publish to PyPI on release tag pushes.
     if: >-
-      github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/zfec-')
+      github.event_name == 'push' &&
+      startsWith(github.event.ref, 'refs/tags/zfec-')
 
     needs:
       - "build_wheels"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,8 @@ jobs:
         if: >-
           github.event_name == 'pull_request'
         with:
+          # Override the default in order to upload it to the testing
+          # deployment.
           repository-url: https://test.pypi.org/legacy/
 
       # Now define a conditional step to upload packages to the production

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
 
     environment:
       name: "release"
-      url: https://pypi.org/project/zfec/
+      url: "https://pypi.org/project/zfec/"
 
     # This permission is mandatory for trusted publishing
     permissions:
@@ -185,7 +185,7 @@ jobs:
 
     environment:
       name: "testpypi"
-      url: https://test.pypi.org/project/zfec/
+      url: "https://test.pypi.org/project/zfec/"
 
     # This permission is mandatory for trusted publishing
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,17 +140,8 @@ jobs:
           path: "dist"
           merge-multiple: true
 
-      # Now define a conditional step to upload packages to the production
-      # instance of PyPI.
-      #
-      # The cases to consider are the same as for the upload to the testing
-      # instance.  This time, we have a conditional that runs only for case
-      # (2).
       - name: "Publish to LIVE PyPI"
         uses: "pypa/gh-action-pypi-publish@release/v1"
-        if: >-
-          github.event_name == 'push' &&
-          startsWith(github.event.ref, 'refs/tags/zfec-')
 
   upload_testpypi:
     name: Publish zfec on TestPyPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
       # instance.  This time, we have a conditional that runs only for case
       # (2).
       - name: "Publish to LIVE PyPI"
-        uses: "pypa/gh-action-pypi-publish@v1.6.4"
+        uses: "pypa/gh-action-pypi-publish@release/v1"
         if: >-
           github.event_name == 'push' &&
           startsWith(github.event.ref, 'refs/tags/zfec-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
   upload_testpypi:
     name: Publish zfec on TestPyPI
 
-    # Publish to TestPyPI on pull requests. 
+    # Publish to TestPyPI on pull requests.
     if: github.event_name == 'pull_request'
 
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,19 @@ jobs:
 # section under "The whole CI/CD workflow".
 #
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow
+#
+# The important bit here is that we use GitHub Actions as the "trusted
+# publisher" to publish packages on both PyPI and TestPyPI.  We do not
+# use long-lived tokens anymore.  Instead, both PyPI and TestPyPI are
+# configured to trust this GH Actions workflow, and the workflow will
+# use a short-lived tokens minted by them.
+#
+# https://docs.pypi.org/trusted-publishers/
+#
+# There is a bit of duplication below but that seems to be necessary
+# because the environment configuration is different for PyPI and
+# TestPyPI.  Perhaps the duplication is not necessary, but let us just
+# stick with the Python Package User Guide's recommendation.
 
   upload_pypi:
     name: Publish zfec on PyPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           merge-multiple: true
 
       - name: "Publish to PyPI"
-        uses: "pypa/gh-action-pypi-publish@release/v1"
+        uses: "pypa/gh-action-pypi-publish@v1.12.4"
         with:
           # Run `twine upload --verbose`.
           verbose: true
@@ -182,7 +182,7 @@ jobs:
           merge-multiple: true
 
       - name: "Publish to TestPyPI"
-        uses: "pypa/gh-action-pypi-publish@release/v1"
+        uses: "pypa/gh-action-pypi-publish@v1.12.4"
         with:
           # Override the default in order to upload to TestPyPi.
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,18 +34,18 @@ jobs:
       # Python versions in sync with the ones in test.yml.
       matrix:
         os:
-          # - "macos-latest"
+          - "macos-latest"
           - "ubuntu-22.04"
-          # - "windows-2022"
+          - "windows-2022"
         wheel-selector:
-          # - "cp39"
-          # - "cp310"
-          # - "cp311"
+          - "cp39"
+          - "cp310"
+          - "cp311"
           - "cp312"
-          # - "cp313"
-          # - "pp38"
-          # - "pp39"
-          # - "pp310"
+          - "cp313"
+          - "pp38"
+          - "pp39"
+          - "pp310"
 
     steps:
       - name: Check out zfec sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       #
       # The conditional in this step should cause it to run only for case (3).
       - name: "Publish to TEST PyPI"
-        uses: "pypa/gh-action-pypi-publish@v1.6.4"
+        uses: "pypa/gh-action-pypi-publish@release/v1"
         with:
           # Override the default in order to upload it to the testing
           # deployment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,10 +154,9 @@ jobs:
           verbose: true
 
   upload_testpypi:
+    # Publish both builds triggered by pull requests and builds
+    # triggered by release tags to TestPyPI.
     name: Publish zfec on TestPyPI
-
-    # Publish to TestPyPI on pull requests.
-    if: github.event_name == 'pull_request'
 
     needs:
       - "build_wheels"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,13 +120,8 @@ jobs:
       - "build_wheels"
       - "build_sdist"
 
-    # It only needs to run once.  It will fetch all of the other build
-    # artifacts created by the other jobs and then upload them.
     runs-on: "ubuntu-latest"
 
-    # Select the GitHub Actions environment that contains the PyPI tokens
-    # necessary to perform uploads.  This was configured manually using the
-    # GitHub web interface.
     environment:
       name: "release"
       url: https://pypi.org/project/zfec/
@@ -167,13 +162,8 @@ jobs:
       - "build_wheels"
       - "build_sdist"
 
-    # It only needs to run once.  It will fetch all of the other build
-    # artifacts created by the other jobs and then upload them.
     runs-on: "ubuntu-latest"
 
-    # Select the GitHub Actions environment that contains the PyPI tokens
-    # necessary to perform uploads.  This was configured manually using the
-    # GitHub web interface.
     environment:
       name: "testpypi"
       url: https://test.pypi.org/project/zfec/
@@ -183,9 +173,8 @@ jobs:
       id-token: write
 
     steps:
-      # Download all artifacts previously built by this workflow to the dist
-      # directory where the publish step can find them.  These are the sdist
-      # and all of the wheels build by the other jobs.
+      # Do the same thing as the download-artfact step in
+      # upload_testpypi job.
       - uses: "actions/download-artifact@v4"
         with:
           pattern: "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,6 @@ jobs:
         with:
           # Override the default in order to upload it to the testing
           # deployment.
-          repository-url: https://test.pypi.org/legacy/
+          repository_url: https://test.pypi.org/legacy/
           # please computer
           verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,8 @@ jobs:
           # Override the default in order to upload it to the testing
           # deployment.
           repository-url: https://test.pypi.org/legacy/
+          # please computer
+          verbose: true
 
       # Now define a conditional step to upload packages to the production
       # instance of PyPI.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,17 +146,6 @@ jobs:
         if: >-
           github.event_name == 'pull_request'
 
-        with:
-          # Authenticate using a token from a PyPI account with upload
-          # permission to the project.  See https://pypi.org/help/#apitoken
-          user: "__token__"
-          # Read it from a GitHub Actions "environment" secret.  See
-          # https://docs.github.com/en/actions/security-guides/encrypted-secrets
-          password: "${{ secrets.testpypi_token }}"
-          # Override the default in order to upload it to the testing
-          # deployment.
-          repository_url: "https://test.pypi.org/legacy/"
-
       # Now define a conditional step to upload packages to the production
       # instance of PyPI.
       #
@@ -168,7 +157,3 @@ jobs:
         if: >-
           github.event_name == 'push' &&
           startsWith(github.event.ref, 'refs/tags/zfec-')
-
-        with:
-          user: "__token__"
-          password: "${{ secrets.pypi_token }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,13 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
+# Both `upload_pypi` and `upload_testpypi` jobs are based on
+# "Publishing package distribution releases using GitHub Actions CI/CD
+# workflows" page of Python Package User Guide.  Specifically see the
+# section under "The whole CI/CD workflow".
+#
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow
+
   upload_pypi:
     name: Publish zfec on PyPI
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,8 +140,11 @@ jobs:
           path: "dist"
           merge-multiple: true
 
-      - name: "Publish to LIVE PyPI"
+      - name: "Publish to PyPI"
         uses: "pypa/gh-action-pypi-publish@release/v1"
+        with:
+          # Run `twine upload --verbose`.
+          verbose: true
 
   upload_testpypi:
     name: Publish zfec on TestPyPI
@@ -172,20 +175,10 @@ jobs:
           path: "dist"
           merge-multiple: true
 
-      # Define a conditional step to upload packages to the testing instance
-      # of PyPI.
-      #
-      # The overall workflow is already restricted so that it runs for:
-      # 1) pushes to master
-      # 2) pushes to release tags
-      # 3) pushes to branches with associated PRs
-      #
-      # The conditional in this step should cause it to run only for case (3).
-      - name: "Publish to TEST PyPI"
+      - name: "Publish to TestPyPI"
         uses: "pypa/gh-action-pypi-publish@release/v1"
         with:
-          # Override the default in order to upload it to the testing
-          # deployment.
+          # Override the default in order to upload to TestPyPi.
           repository_url: https://test.pypi.org/legacy/
-          # please computer
+          # Run `twine upload --verbose`.
           verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,18 +34,18 @@ jobs:
       # Python versions in sync with the ones in test.yml.
       matrix:
         os:
-          - "macos-latest"
+          # - "macos-latest"
           - "ubuntu-22.04"
-          - "windows-2022"
+          # - "windows-2022"
         wheel-selector:
-          - "cp39"
-          - "cp310"
-          - "cp311"
+          # - "cp39"
+          # - "cp310"
+          # - "cp311"
           - "cp312"
-          - "cp313"
-          - "pp38"
-          - "pp39"
-          - "pp310"
+          # - "cp313"
+          # - "pp38"
+          # - "pp39"
+          # - "pp310"
 
     steps:
       - name: Check out zfec sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,6 @@ jobs:
         uses: "pypa/gh-action-pypi-publish@v1.12.4"
         with:
           # Override the default in order to upload to TestPyPi.
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           # Run `twine upload --verbose`.
           verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,8 @@ jobs:
     # Select the GitHub Actions environment that contains the PyPI tokens
     # necessary to perform uploads.  This was configured manually using the
     # GitHub web interface.
-    environment: "release"
+    environment:
+      name: "release"
 
     # This permission is mandatory for trusted publishing
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,8 @@ jobs:
           # Override the default in order to upload it to the testing
           # deployment.
           repository-url: https://test.pypi.org/legacy/
+          # Do we need a different URL, or a whole new environment?
+          url: https://test.pypi.org/project/zfec/
           # please computer
           verbose: true
 


### PR DESCRIPTION
Attempting to resolve #127; stacked on top of #121.  I have added the repository owner (tahoe-lafs), repository name (zfec), workflow file (build.yml), and environment (release or testpypi) to add GHA as a publisher both on TestPyPI and PyPI.

![image](https://github.com/user-attachments/assets/b3174bde-a7a7-4bce-a454-89786b253551)
