### PR TITLE
Update `flake.nix`

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,45 @@
+name: "Nix"
+
+# This workflow validates flake.nix. Also tests/builds the Haskell
+# package.
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  nix:
+    name: "${{ matrix.system }}"
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: "x86_64-linux"
+            runner: "ubuntu-latest"
+          - system: "x86_64-darwin"
+            runner: "macos-15-intel"
+          - system: "aarch64-darwin"
+            runner: "macos-15"
+
+    steps:
+      - name: Check out zfec sources
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: tahoe-lafs-zfec
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Check flake
+        run: nix flake check --system "${{ matrix.system }}" --print-build-logs
+
+      - name: Build artifacts
+        run: nix build --system "${{ matrix.system }}" .#default --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ dist/*
 cabal.sandbox.config
 .tox/
 .eggs/
+.hypothesis/
+_trial_temp/
+.nix-cache/
+dist-newstyle/
+result

--- a/fec.cabal
+++ b/fec.cabal
@@ -34,7 +34,7 @@ library
     , base        >=4.9  && <5
     , bytestring  >=0.10 && <0.13
     , deepseq     >=1.4  && <1.6
-    , extra       >=1.7  && <1.8
+    , extra       >=1.7  && <1.9
 
   exposed-modules:    Codec.FEC
   default-language:   Haskell2010
@@ -71,7 +71,7 @@ test-suite tests
     , data-serializer       >=0.3  && <0.4
     , fec
     , hspec                 >=2.7  && <2.12
-    , QuickCheck            >=2.14 && <2.15
+    , QuickCheck            >=2.14 && <2.16
     , quickcheck-instances  >=0.3  && <0.4
     , random                >=1.1  && <1.3
 

--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -77,11 +80,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1695048281,
-        "narHash": "sha256-zkXDTX2aM6mOiYZlc60NJTAb3mrDrrlNN7lHE3GSvhk=",
+        "lastModified": 1696872058,
+        "narHash": "sha256-QCfoTnGtUABi5KbWXrTh4fhvLGP5B0gAG6KU1ACd96s=",
         "ref": "main",
-        "rev": "628ffddf1a6c59036fa1a4b76daddb9b34065e04",
-        "revCount": 17,
+        "rev": "683abab784ee38ea61863b3594d3777345f420d6",
+        "revCount": 20,
         "type": "git",
         "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
       },
@@ -93,16 +96,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670543317,
-        "narHash": "sha256-4mMR56rtxKr+Gwz399jFr4i76SQZxsLWxxyfQlPXRm0=",
+        "lastModified": 1774244481,
+        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7a6a010c3a1d00f8470a5ca888f2f927f1860a19",
+        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -156,6 +159,21 @@
         "flake-utils": "flake-utils",
         "hs-flake-utils": "hs-flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,97 +1,36 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "hs-flake-utils",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
-        "repo": "gitignore.nix",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
-    "hs-flake-utils": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": "pre-commit-hooks"
-      },
+    "haskell-flake": {
       "locked": {
-        "lastModified": 1696872058,
-        "narHash": "sha256-QCfoTnGtUABi5KbWXrTh4fhvLGP5B0gAG6KU1ACd96s=",
-        "ref": "main",
-        "rev": "683abab784ee38ea61863b3594d3777345f420d6",
-        "revCount": 20,
-        "type": "git",
-        "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
+        "lastModified": 1779033714,
+        "narHash": "sha256-hhqI8XWucXQB5Yo6KwECkD2nldqNSd+ftfY3YoJT2/A=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "375c8e3bf7c43a08eb74b60552de96f2561ade76",
+        "type": "github"
       },
       "original": {
-        "ref": "main",
-        "type": "git",
-        "url": "https://whetstone.private.storage/jcalderone/hs-flake-utils.git"
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
       }
     },
     "nixpkgs": {
@@ -107,6 +46,21 @@
         "owner": "nixos",
         "ref": "nixos-26.05",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -126,71 +80,12 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1673800717,
-        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": [
-          "hs-flake-utils",
-          "flake-utils"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "hs-flake-utils",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1677722096,
-        "narHash": "sha256-7mjVMvCs9InnrRybBfr5ohqcOz+pyEX8m22C1XsDilg=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "61a3511668891c68ebd19d40122150b98dc2fe3b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "hs-flake-utils": "hs-flake-utils",
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
         "nixpkgs": "nixpkgs",
         "nixpkgs-old": "nixpkgs-old"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -110,6 +110,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1673800717,
@@ -158,7 +174,8 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "hs-flake-utils": "hs-flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-old": "nixpkgs-old"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       hslib = hs-flake-utils.lib {
         pkgs = nixpkgs.legacyPackages.${system};
         src = ./.;
-        compilerVersion = "ghc8107";
+        compilerVersion = "ghc9103";
         packageName = "fec";
       };
     in {

--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,9 @@
               ];
             };
 
-          # packages are auto-wired via haskell-flake
-          packages = config.haskellProjects.default.outputs.packages;
+          # # packages are auto-wired via haskell-flake
+          # packages = config.haskellProjects.default.outputs.packages;
+
           checks = config.haskellProjects.default.outputs.checks;
           apps = (config.haskellProjects.default.outputs.apps or {}) // {
             hlint = {

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,14 @@
       ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      # Systems we support
-      systems = [ "x86_64-linux" ];
+      # I am testing only on x86_64-linux, but I hope that the other
+      # systems also probably should work.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
 
       perSystem =
         { system, pkgs, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
           packages = config.haskellProjects.default.outputs.packages;
 
           checks = config.haskellProjects.default.outputs.checks;
+
           apps = (config.haskellProjects.default.outputs.apps or {}) // {
             hlint = {
               type = "app";
@@ -90,21 +91,14 @@
             };
             cabal-test = {
               type = "app";
-              program = pkgs'.haskell.packages.ghc9103.cabal-install;
-              # args = [ "test" ];
-              # extraRuntimeInputs = [ pkgs'.gnused pkgs'.gawk ];
-
-              # program = pkgs'.writeShellApplication {
-              #   name = "cabal-test";
-              #   runtimeInputs = [
-              #     # pkgs'.haskell.packages.ghc9103
-              #     pkgs'.gnused
-              #     pkgs'.gawk
-              #   ];
-              #   text = ''
-              #     ${pkgs'.haskell.packages.ghc9103.cabal-install}/bin/cabal test "$@"
-              #   '';
-              # };
+              program = "${pkgs'.writeShellApplication {
+                name = "cabal-test";
+                runtimeInputs = [
+                  pkgs'.haskell.packages.ghc9103.ghc
+                  pkgs'.haskell.packages.ghc9103.cabal-install
+                ];
+                text = "cabal test";
+              }}/bin/cabal-test";
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Nix Inputs
-    nixpkgs.url = github:nixos/nixpkgs/?ref=nixos-22.11;
+    nixpkgs.url = github:nixos/nixpkgs/?ref=nixos-25.11;
     flake-utils.url = github:numtide/flake-utils;
     hs-flake-utils.url = "git+https://whetstone.private.storage/jcalderone/hs-flake-utils.git?ref=main";
     hs-flake-utils.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           pkgs.python311
           pkgs.python312
           pkgs.python313
+          pkgs.python314
           pkgs.pypy310
 
           # Python/PyPy matrix extras from older channel
@@ -54,10 +55,7 @@
           oldpkgs.python310
           oldpkgs.pypy39
 
-          # Extra CI/release tools
-          pkgs.python3Packages.build
-          pkgs.twine
-          pkgs.python3Packages.twisted
+          # The tox test tool
           pkgs.python3Packages.tox
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
                   pkgs'.haskell.packages.ghc9103.ghc
                   pkgs'.haskell.packages.ghc9103.cabal-install
                 ];
-                text = "cabal test";
+                text = "cabal test --enable-tests";
               }}/bin/cabal-test";
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,11 @@
           apps = (config.haskellProjects.default.outputs.apps or {}) // {
             hlint = {
               type = "app";
-              program = pkgs'.haskell.packages.ghc9103.hlint;
+              program = "${pkgs'.writeShellApplication {
+                name = "hlint";
+                runtimeInputs = [ pkgs'.haskell.packages.ghc9103.hlint ];
+                text = "hlint haskell/";
+              }}/bin/hlint";
             };
             cabal-test = {
               type = "app";

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,8 @@
             ];
           };
 
-          # Development shell – automatically picks up the Haskell project in this repo
+          # Development shell automatically picks up the Haskell
+          # project in this repo.
           devShells.default = pkgs'.mkShell {
             buildInputs = [
               ghc.cabal-install

--- a/flake.nix
+++ b/flake.nix
@@ -50,8 +50,27 @@
           );
           ghc = pkgs'.haskell.packages.ghc9103;
           python = pkgs'.python312;
+          haskellVersion = "0.2.0";
           zfecVersion = "1.6.0.0";
           haskellFec = config.haskellProjects.default.outputs.packages.fec.package;
+          haskellSdist = pkgs'.runCommand "fec-${haskellVersion}-sdist" {
+            nativeBuildInputs = [
+              ghc.cabal-install
+              ghc.ghc
+            ];
+          } ''
+            cp -R ${self} source
+            chmod -R u+w source
+            cd source
+
+            export HOME=$TMPDIR/home
+            export CABAL_CONFIG=$TMPDIR/cabal/config
+            mkdir -p "$HOME" "$(dirname "$CABAL_CONFIG")"
+            touch "$CABAL_CONFIG"
+
+            mkdir -p $out
+            cabal sdist --output-dir=$out
+          '';
           pythonZfec = python.pkgs.buildPythonPackage {
             pname = "zfec";
             version = zfecVersion;
@@ -133,6 +152,7 @@
             ];
           };
 
+          packages.haskellSdist = haskellSdist;
           packages.python = pythonZfec;
           packages.pythonWheel = pythonZfec.dist;
           packages.pythonSdist = pythonSdist;
@@ -140,6 +160,7 @@
             mkdir -p $out/dist
             ln -s ${haskellFec} $out/haskell
             ln -s ${pythonZfec} $out/python
+            ln -s ${haskellSdist}/*.tar.gz $out/dist/
             ln -s ${pythonZfec.dist}/*.whl $out/dist/
             ln -s ${pythonSdist}/*.tar.gz $out/dist/
 
@@ -152,7 +173,7 @@
               echo "Python package:"
               echo "  python -> ${pythonZfec}"
               echo
-              echo "Python distributions:"
+              echo "Distribution artifacts:"
               for artifact in $out/dist/*; do
                 echo "  dist/$(basename "$artifact")"
               done

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
           pkgs.python3Packages.build
           pkgs.twine
           pkgs.python3Packages.twisted
+          pkgs.python3Packages.tox
         ];
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -137,11 +137,26 @@
           packages.pythonWheel = pythonZfec.dist;
           packages.pythonSdist = pythonSdist;
           packages.default = pkgs'.runCommand "zfec-all" { } ''
-            mkdir -p $out
+            mkdir -p $out/dist
             ln -s ${haskellFec} $out/haskell
             ln -s ${pythonZfec} $out/python
-            ln -s ${pythonZfec.dist} $out/python-wheel
-            ln -s ${pythonSdist} $out/python-sdist
+            ln -s ${pythonZfec.dist}/*.whl $out/dist/
+            ln -s ${pythonSdist}/*.tar.gz $out/dist/
+
+            {
+              echo "zfec build artifacts"
+              echo
+              echo "Haskell package:"
+              echo "  haskell -> ${haskellFec}"
+              echo
+              echo "Python package:"
+              echo "  python -> ${pythonZfec}"
+              echo
+              echo "Python distributions:"
+              for artifact in $out/dist/*; do
+                echo "  dist/$(basename "$artifact")"
+              done
+            } > $out/ARTIFACTS.txt
           '';
 
           apps = (config.haskellProjects.default.outputs.apps or { }) // {

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
           );
           ghc = pkgs'.haskell.packages.ghc9103;
           python = pkgs'.python312;
-          zfecVersion = "1.6.0.0";
           haskellFec = config.haskellProjects.default.outputs.packages.fec.package;
           haskellVersion = haskellFec.version;
           haskellSdist =
@@ -76,7 +75,7 @@
               '';
           pythonZfec = python.pkgs.buildPythonPackage {
             pname = "zfec";
-            version = zfecVersion;
+            version = "dev";
             pyproject = true;
 
             src = self;
@@ -88,11 +87,6 @@
               python.pkgs.twisted
             ];
 
-            postPatch = ''
-              substituteInPlace versioneer.py zfec/_version.py \
-                --replace-fail '"0+unknown"' '"${zfecVersion}"'
-            '';
-
             checkPhase = ''
               trial zfec
             '';
@@ -100,7 +94,7 @@
             pythonImportsCheck = [ "zfec" ];
           };
           pythonSdist =
-            pkgs'.runCommand "zfec-${zfecVersion}-sdist"
+            pkgs'.runCommand "zfec-python-sdist"
               {
                 nativeBuildInputs = [
                   python
@@ -111,9 +105,6 @@
                 cp -R ${self} source
                 chmod -R u+w source
                 cd source
-
-                substituteInPlace versioneer.py zfec/_version.py \
-                  --replace-fail '"0+unknown"' '"${zfecVersion}"'
 
                 mkdir -p $out
                 python setup.py sdist --dist-dir $out

--- a/flake.nix
+++ b/flake.nix
@@ -3,75 +3,75 @@
 
   inputs = {
     # Nix Inputs
-    nixpkgs.url = github:nixos/nixpkgs/?ref=nixos-26.05;
-    nixpkgs-old.url = github:nixos/nixpkgs/?ref=nixos-23.11;
-    flake-utils.url = github:numtide/flake-utils;
-    hs-flake-utils.url = "git+https://whetstone.private.storage/jcalderone/hs-flake-utils.git?ref=main";
-    hs-flake-utils.inputs.nixpkgs.follows = "nixpkgs";
+    nixpkgs.url = "github:nixos/nixpkgs/?ref=nixos-26.05";
+    nixpkgs-old.url = "github:nixos/nixpkgs/?ref=nixos-23.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    haskell-flake.url = "github:srid/haskell-flake";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    nixpkgs-old,
-    flake-utils,
-    hs-flake-utils,
-  }: let
-    ulib = flake-utils.lib;
-  in
-    ulib.eachSystem ["x86_64-linux"] (system: let
-      oldpkgs = nixpkgs-old.legacyPackages.${system};
-      pkgs = nixpkgs.legacyPackages.${system}.extend (self: super: {
-        python39Packages = oldpkgs.python39Packages;
-      });
-      hsPkgs = pkgs.haskell.packages.ghc9103;
-      hslib = hs-flake-utils.lib {
-        pkgs = pkgs;
-        src = ./.;
-        compilerVersion = "ghc9103";
-        packageName = "fec";
-      };
-    in {
-      checks = hslib.checks {};
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      nixpkgs-old,
+      flake-parts,
+      haskell-flake,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      # Systems we support
+      systems = [ "x86_64-linux" ];
 
-      devShells.default = hsPkgs.shellFor {
-        packages = p: [];
-        buildInputs = [
-          hsPkgs.cabal-install
-          hsPkgs.ghcid
-          hsPkgs.haskell-language-server
-          pkgs.gawk
-          pkgs.gnused
+      perSystem =
+        { system, pkgs, ... }:
+        let
+          # Bring in the older python packages we need
+          pkgsOld = nixpkgs-old.legacyPackages.${system};
+          pkgs' = pkgs.extend (
+            self: super: {
+              python39Packages = pkgsOld.python39Packages;
+              python39 = pkgsOld.python39;
+              python310 = pkgsOld.python310;
+              pypy39 = pkgsOld.pypy39;
+            }
+          );
+          # Haskell utilities from haskell-flake
+          hs = haskell-flake.lib { inherit pkgs'; };
+        in
+        {
+          # Development shell – automatically picks up the Haskell project in this repo
+          devShells.default =
+            let
+              hspkgs = pkgs'.haskell.packages.ghc9103;
+            in
+            pkgs'.mkShell {
+              buildInputs = [
+                hspkgs.cabal-install
+                hspkgs.ghcid
+                hspkgs.haskell-language-server
 
-          # Python/PyPy matrix (current channel)
-          pkgs.python311
-          pkgs.python312
-          pkgs.python313
-          pkgs.python314
-          pkgs.pypy310
+                pkgs'.gawk
+                pkgs'.gnused
 
-          # Python/PyPy matrix extras from older channel
-          oldpkgs.python39
-          oldpkgs.python310
-          oldpkgs.pypy39
+                # Python/PyPy matrix from the current channel.
+                pkgs'.python311
+                pkgs'.python312
+                pkgs'.python313
+                pkgs'.python314
+                pkgs'.pypy310
+                pkgs'.python3Packages.tox
 
-          # The tox test tool
-          pkgs.python3Packages.tox
-        ];
-      };
+                # Python/PyPy matrix extras from older channel.
+                pkgs'.python39
+                pkgs'.python310
+                pkgs'.pypy39
+              ];
+            };
 
-      packages = hslib.packages {};
-      apps = {
-        hlint = hslib.apps.hlint {argv = ["haskell/"];};
-        cabal-test = hslib.apps.cabal-test {
-          extraRuntimeInputs = pkgs: [
-            # Some build-time dependencies of old-time, a transitive
-            # dependency of ours...
-            pkgs.gnused
-            pkgs.gawk
-          ];
-          testTargetName = "test:tests";
+          # Expose the Haskell packages (empty placeholder for now)
+          packages = { };
+          checks = { };
+          apps = { };
         };
-      };
-    });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,10 @@
     ulib = flake-utils.lib;
   in
     ulib.eachSystem ["x86_64-linux"] (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
       oldpkgs = nixpkgs-old.legacyPackages.${system};
+      pkgs = nixpkgs.legacyPackages.${system}.extend (self: super: {
+        python39Packages = oldpkgs.python39Packages;
+      });
       hsPkgs = pkgs.haskell.packages.ghc9103;
       hslib = hs-flake-utils.lib {
         pkgs = pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -18,15 +18,28 @@
     ulib = flake-utils.lib;
   in
     ulib.eachSystem ["x86_64-linux"] (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      hsPkgs = pkgs.haskell.packages.ghc9103;
       hslib = hs-flake-utils.lib {
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = pkgs;
         src = ./.;
         compilerVersion = "ghc9103";
         packageName = "fec";
       };
     in {
       checks = hslib.checks {};
-      devShells = hslib.devShells {};
+
+      devShells.default = hsPkgs.shellFor {
+        packages = p: [];
+        buildInputs = [
+          hsPkgs.cabal-install
+          hsPkgs.ghcid
+          hsPkgs.haskell-language-server
+          pkgs.gawk
+          pkgs.gnused
+        ];
+      };
+
       packages = hslib.packages {};
       apps = {
         hlint = hslib.apps.hlint {argv = ["haskell/"];};

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,11 @@
             ];
           };
 
+          # This will make `nix build` build the Haskell package.  We
+          # can also run `nix build .#fec` or `nix build
+          # .#packages.x86_64-linux.fec`
+          packages.default = config.haskellProjects.default.outputs.packages.fec.package;
+
           apps = (config.haskellProjects.default.outputs.apps or { }) // {
             hlint = {
               type = "app";

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,8 @@
         {
           # Haskell utilities via haskell-flake
           haskellProjects.default = {
+            basePackages = ghc;
+
             # Automatically discover packages and expose them
             autoWire = [
               "packages"

--- a/flake.nix
+++ b/flake.nix
@@ -53,24 +53,27 @@
           haskellVersion = "0.2.0";
           zfecVersion = "1.6.0.0";
           haskellFec = config.haskellProjects.default.outputs.packages.fec.package;
-          haskellSdist = pkgs'.runCommand "fec-${haskellVersion}-sdist" {
-            nativeBuildInputs = [
-              ghc.cabal-install
-              ghc.ghc
-            ];
-          } ''
-            cp -R ${self} source
-            chmod -R u+w source
-            cd source
+          haskellSdist =
+            pkgs'.runCommand "fec-${haskellVersion}-sdist"
+              {
+                nativeBuildInputs = [
+                  ghc.cabal-install
+                  ghc.ghc
+                ];
+              }
+              ''
+                cp -R ${self} source
+                chmod -R u+w source
+                cd source
 
-            export HOME=$TMPDIR/home
-            export CABAL_CONFIG=$TMPDIR/cabal/config
-            mkdir -p "$HOME" "$(dirname "$CABAL_CONFIG")"
-            touch "$CABAL_CONFIG"
+                export HOME=$TMPDIR/home
+                export CABAL_CONFIG=$TMPDIR/cabal/config
+                mkdir -p "$HOME" "$(dirname "$CABAL_CONFIG")"
+                touch "$CABAL_CONFIG"
 
-            mkdir -p $out
-            cabal sdist --output-dir=$out
-          '';
+                mkdir -p $out
+                cabal sdist --output-dir=$out
+              '';
           pythonZfec = python.pkgs.buildPythonPackage {
             pname = "zfec";
             version = zfecVersion;
@@ -96,22 +99,25 @@
 
             pythonImportsCheck = [ "zfec" ];
           };
-          pythonSdist = pkgs'.runCommand "zfec-${zfecVersion}-sdist" {
-            nativeBuildInputs = [
-              python
-              python.pkgs.setuptools
-            ];
-          } ''
-            cp -R ${self} source
-            chmod -R u+w source
-            cd source
+          pythonSdist =
+            pkgs'.runCommand "zfec-${zfecVersion}-sdist"
+              {
+                nativeBuildInputs = [
+                  python
+                  python.pkgs.setuptools
+                ];
+              }
+              ''
+                cp -R ${self} source
+                chmod -R u+w source
+                cd source
 
-            substituteInPlace versioneer.py zfec/_version.py \
-              --replace-fail '"0+unknown"' '"${zfecVersion}"'
+                substituteInPlace versioneer.py zfec/_version.py \
+                  --replace-fail '"0+unknown"' '"${zfecVersion}"'
 
-            mkdir -p $out
-            python setup.py sdist --dist-dir $out
-          '';
+                mkdir -p $out
+                python setup.py sdist --dist-dir $out
+              '';
         in
         {
           # Haskell utilities via haskell-flake

--- a/flake.nix
+++ b/flake.nix
@@ -91,8 +91,20 @@
             cabal-test = {
               type = "app";
               program = pkgs'.haskell.packages.ghc9103.cabal-install;
-              argv = [ "test" ];
-              extraRuntimeInputs = [ pkgs'.gnused pkgs'.gawk ];
+              # args = [ "test" ];
+              # extraRuntimeInputs = [ pkgs'.gnused pkgs'.gawk ];
+
+              # program = pkgs'.writeShellApplication {
+              #   name = "cabal-test";
+              #   runtimeInputs = [
+              #     # pkgs'.haskell.packages.ghc9103
+              #     pkgs'.gnused
+              #     pkgs'.gawk
+              #   ];
+              #   text = ''
+              #     ${pkgs'.haskell.packages.ghc9103.cabal-install}/bin/cabal test "$@"
+              #   '';
+              # };
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,12 @@
       ];
 
       perSystem =
-        { system, pkgs, config, ... }:
+        {
+          system,
+          pkgs,
+          config,
+          ...
+        }:
         let
           # Bring in the older python packages we need
           pkgsOld = nixpkgs-old.legacyPackages.${system};
@@ -48,58 +53,66 @@
           # Haskell utilities via haskell-flake
           haskellProjects.default = {
             # Automatically discover packages and expose them
-            autoWire = [ "packages" "checks" "apps" ];
+            autoWire = [
+              "packages"
+              "checks"
+              "apps"
+            ];
           };
 
           # Development shell – automatically picks up the Haskell project in this repo
           devShells.default = pkgs'.mkShell {
-              buildInputs = [
-                ghc.cabal-install
-                ghc.ghcid
-                ghc.haskell-language-server
+            buildInputs = [
+              ghc.cabal-install
+              ghc.ghcid
+              ghc.haskell-language-server
 
-                pkgs'.gawk
-                pkgs'.gnused
+              pkgs'.gawk
+              pkgs'.gnused
 
-                # Python/PyPy matrix from the current channel.
-                pkgs'.python311
-                pkgs'.python312
-                pkgs'.python313
-                pkgs'.python314
-                pkgs'.pypy310
-                pkgs'.python3Packages.tox
+              # Python/PyPy matrix from the current channel.
+              pkgs'.python311
+              pkgs'.python312
+              pkgs'.python313
+              pkgs'.python314
+              pkgs'.pypy310
+              pkgs'.python3Packages.tox
 
-                # Python/PyPy matrix extras from older channel.
-                pkgs'.python39
-                pkgs'.python310
-                pkgs'.pypy39
-              ];
-            };
+              # Python/PyPy matrix extras from older channel.
+              pkgs'.python39
+              pkgs'.python310
+              pkgs'.pypy39
+            ];
+          };
 
           # packages are auto-wired via haskell-flake
           packages = config.haskellProjects.default.outputs.packages;
 
           checks = config.haskellProjects.default.outputs.checks;
 
-          apps = (config.haskellProjects.default.outputs.apps or {}) // {
+          apps = (config.haskellProjects.default.outputs.apps or { }) // {
             hlint = {
               type = "app";
-              program = "${pkgs'.writeShellApplication {
-                name = "hlint";
-                runtimeInputs = [ ghc.hlint ];
-                text = "hlint haskell/";
-              }}/bin/hlint";
+              program = "${
+                pkgs'.writeShellApplication {
+                  name = "hlint";
+                  runtimeInputs = [ ghc.hlint ];
+                  text = "hlint haskell/";
+                }
+              }/bin/hlint";
             };
             cabal-test = {
               type = "app";
-              program = "${pkgs'.writeShellApplication {
-                name = "cabal-test";
-                runtimeInputs = [
-                  ghc.ghc
-                  ghc.cabal-install
-                ];
-                text = "cabal test --enable-tests";
-              }}/bin/cabal-test";
+              program = "${
+                pkgs'.writeShellApplication {
+                  name = "cabal-test";
+                  runtimeInputs = [
+                    ghc.ghc
+                    ghc.cabal-install
+                  ];
+                  text = "cabal test --enable-tests";
+                }
+              }/bin/cabal-test";
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Nix Inputs
-    nixpkgs.url = github:nixos/nixpkgs/?ref=nixos-25.11;
+    nixpkgs.url = github:nixos/nixpkgs/?ref=nixos-26.05;
     nixpkgs-old.url = github:nixos/nixpkgs/?ref=nixos-23.11;
     flake-utils.url = github:numtide/flake-utils;
     hs-flake-utils.url = "git+https://whetstone.private.storage/jcalderone/hs-flake-utils.git?ref=main";

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
               pypy39 = pkgsOld.pypy39;
             }
           );
+          ghc = pkgs'.haskell.packages.ghc9103;
         in
         {
           # Haskell utilities via haskell-flake
@@ -51,15 +52,11 @@
           };
 
           # Development shell – automatically picks up the Haskell project in this repo
-          devShells.default =
-            let
-              hspkgs = pkgs'.haskell.packages.ghc9103;
-            in
-            pkgs'.mkShell {
+          devShells.default = pkgs'.mkShell {
               buildInputs = [
-                hspkgs.cabal-install
-                hspkgs.ghcid
-                hspkgs.haskell-language-server
+                ghc.cabal-install
+                ghc.ghcid
+                ghc.haskell-language-server
 
                 pkgs'.gawk
                 pkgs'.gnused
@@ -89,7 +86,7 @@
               type = "app";
               program = "${pkgs'.writeShellApplication {
                 name = "hlint";
-                runtimeInputs = [ pkgs'.haskell.packages.ghc9103.hlint ];
+                runtimeInputs = [ ghc.hlint ];
                 text = "hlint haskell/";
               }}/bin/hlint";
             };
@@ -98,8 +95,8 @@
               program = "${pkgs'.writeShellApplication {
                 name = "cabal-test";
                 runtimeInputs = [
-                  pkgs'.haskell.packages.ghc9103.ghc
-                  pkgs'.haskell.packages.ghc9103.cabal-install
+                  ghc.ghc
+                  ghc.cabal-install
                 ];
                 text = "cabal test --enable-tests";
               }}/bin/cabal-test";

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     # Nix Inputs
     nixpkgs.url = github:nixos/nixpkgs/?ref=nixos-25.11;
+    nixpkgs-old.url = github:nixos/nixpkgs/?ref=nixos-23.11;
     flake-utils.url = github:numtide/flake-utils;
     hs-flake-utils.url = "git+https://whetstone.private.storage/jcalderone/hs-flake-utils.git?ref=main";
     hs-flake-utils.inputs.nixpkgs.follows = "nixpkgs";
@@ -12,6 +13,7 @@
   outputs = {
     self,
     nixpkgs,
+    nixpkgs-old,
     flake-utils,
     hs-flake-utils,
   }: let
@@ -19,6 +21,7 @@
   in
     ulib.eachSystem ["x86_64-linux"] (system: let
       pkgs = nixpkgs.legacyPackages.${system};
+      oldpkgs = nixpkgs-old.legacyPackages.${system};
       hsPkgs = pkgs.haskell.packages.ghc9103;
       hslib = hs-flake-utils.lib {
         pkgs = pkgs;
@@ -38,11 +41,16 @@
           pkgs.gawk
           pkgs.gnused
 
-          # Python/PyPy matrix (closest available on nixos-25.11)
+          # Python/PyPy matrix (current channel)
           pkgs.python311
           pkgs.python312
           pkgs.python313
           pkgs.pypy310
+
+          # Python/PyPy matrix extras from older channel
+          oldpkgs.python39
+          oldpkgs.python310
+          oldpkgs.pypy39
 
           # Extra CI/release tools
           pkgs.python3Packages.build

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,17 @@
           hsPkgs.haskell-language-server
           pkgs.gawk
           pkgs.gnused
+
+          # Python/PyPy matrix (closest available on nixos-25.11)
+          pkgs.python311
+          pkgs.python312
+          pkgs.python313
+          pkgs.pypy310
+
+          # Extra CI/release tools
+          pkgs.python3Packages.build
+          pkgs.twine
+          pkgs.python3Packages.twisted
         ];
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -79,10 +79,21 @@
               ];
             };
 
-          # Expose the Haskell project outputs
-          packages = config.haskellProjects.default.packages;
-          checks = config.haskellProjects.default.checks;
-          apps = config.haskellProjects.default.apps or { };
+          # packages are auto-wired via haskell-flake
+          packages = config.haskellProjects.default.outputs.packages;
+          checks = config.haskellProjects.default.outputs.checks;
+          apps = (config.haskellProjects.default.outputs.apps or {}) // {
+            hlint = {
+              type = "app";
+              program = pkgs'.haskell.packages.ghc9103.hlint;
+            };
+            cabal-test = {
+              type = "app";
+              program = pkgs'.haskell.packages.ghc9103.cabal-install;
+              argv = [ "test" ];
+              extraRuntimeInputs = [ pkgs'.gnused pkgs'.gawk ];
+            };
+          };
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,28 @@
           '';
 
           apps = (config.haskellProjects.default.outputs.apps or { }) // {
+            build-artifacts = {
+              type = "app";
+              program = "${
+                pkgs'.writeShellApplication {
+                  name = "build-artifacts";
+                  runtimeInputs = [
+                    pkgs'.coreutils
+                    pkgs'.nix
+                  ];
+                  text = ''
+                    nix build "$@"
+
+                    if [ -f result/ARTIFACTS.txt ]; then
+                      printf '\n'
+                      cat result/ARTIFACTS.txt
+                    else
+                      printf '\nBuild finished, but result/ARTIFACTS.txt was not found.\n'
+                    fi
+                  '';
+                }
+              }/bin/build-artifacts";
+            };
             hlint = {
               type = "app";
               program = "${

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,9 @@
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [ haskell-flake.flakeModule ];
-      # I am testing only on x86_64-linux, but I hope that the other
-      # systems also probably should work.
+
+      # I have been testing things only on x86_64-linux.  Hopefully
+      # the other systems also should Just Work (tm).
       systems = [
         "x86_64-linux"
         "aarch64-linux"

--- a/flake.nix
+++ b/flake.nix
@@ -50,9 +50,9 @@
           );
           ghc = pkgs'.haskell.packages.ghc9103;
           python = pkgs'.python312;
-          haskellVersion = "0.2.0";
           zfecVersion = "1.6.0.0";
           haskellFec = config.haskellProjects.default.outputs.packages.fec.package;
+          haskellVersion = haskellFec.version;
           haskellSdist =
             pkgs'.runCommand "fec-${haskellVersion}-sdist"
               {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
       ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ haskell-flake.flakeModule ];
       # I am testing only on x86_64-linux, but I hope that the other
       # systems also probably should work.
       systems = [
@@ -29,7 +30,7 @@
       ];
 
       perSystem =
-        { system, pkgs, ... }:
+        { system, pkgs, config, ... }:
         let
           # Bring in the older python packages we need
           pkgsOld = nixpkgs-old.legacyPackages.${system};
@@ -41,10 +42,14 @@
               pypy39 = pkgsOld.pypy39;
             }
           );
-          # Haskell utilities from haskell-flake
-          hs = haskell-flake.lib { inherit pkgs'; };
         in
         {
+          # Haskell utilities via haskell-flake
+          haskellProjects.default = {
+            # Automatically discover packages and expose them
+            autoWire = [ "packages" "checks" "apps" ];
+          };
+
           # Development shell – automatically picks up the Haskell project in this repo
           devShells.default =
             let
@@ -74,10 +79,10 @@
               ];
             };
 
-          # Expose the Haskell packages (empty placeholder for now)
-          packages = { };
-          checks = { };
-          apps = { };
+          # Expose the Haskell project outputs
+          packages = config.haskellProjects.default.packages;
+          checks = config.haskellProjects.default.checks;
+          apps = config.haskellProjects.default.apps or { };
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,50 @@
             }
           );
           ghc = pkgs'.haskell.packages.ghc9103;
+          python = pkgs'.python312;
+          zfecVersion = "1.6.0.0";
+          haskellFec = config.haskellProjects.default.outputs.packages.fec.package;
+          pythonZfec = python.pkgs.buildPythonPackage {
+            pname = "zfec";
+            version = zfecVersion;
+            pyproject = true;
+
+            src = self;
+
+            nativeBuildInputs = [ python.pkgs.setuptools ];
+            propagatedBuildInputs = [ python.pkgs.pyutil ];
+            nativeCheckInputs = [
+              python.pkgs.hypothesis
+              python.pkgs.twisted
+            ];
+
+            postPatch = ''
+              substituteInPlace versioneer.py zfec/_version.py \
+                --replace-fail '"0+unknown"' '"${zfecVersion}"'
+            '';
+
+            checkPhase = ''
+              trial zfec
+            '';
+
+            pythonImportsCheck = [ "zfec" ];
+          };
+          pythonSdist = pkgs'.runCommand "zfec-${zfecVersion}-sdist" {
+            nativeBuildInputs = [
+              python
+              python.pkgs.setuptools
+            ];
+          } ''
+            cp -R ${self} source
+            chmod -R u+w source
+            cd source
+
+            substituteInPlace versioneer.py zfec/_version.py \
+              --replace-fail '"0+unknown"' '"${zfecVersion}"'
+
+            mkdir -p $out
+            python setup.py sdist --dist-dir $out
+          '';
         in
         {
           # Haskell utilities via haskell-flake
@@ -89,10 +133,16 @@
             ];
           };
 
-          # This will make `nix build` build the Haskell package.  We
-          # can also run `nix build .#fec` or `nix build
-          # .#packages.x86_64-linux.fec`
-          packages.default = config.haskellProjects.default.outputs.packages.fec.package;
+          packages.python = pythonZfec;
+          packages.pythonWheel = pythonZfec.dist;
+          packages.pythonSdist = pythonSdist;
+          packages.default = pkgs'.runCommand "zfec-all" { } ''
+            mkdir -p $out
+            ln -s ${haskellFec} $out/haskell
+            ln -s ${pythonZfec} $out/python
+            ln -s ${pythonZfec.dist} $out/python-wheel
+            ln -s ${pythonSdist} $out/python-sdist
+          '';
 
           apps = (config.haskellProjects.default.outputs.apps or { }) // {
             hlint = {

--- a/flake.nix
+++ b/flake.nix
@@ -86,11 +86,6 @@
             ];
           };
 
-          # packages are auto-wired via haskell-flake
-          packages = config.haskellProjects.default.outputs.packages;
-
-          checks = config.haskellProjects.default.outputs.checks;
-
           apps = (config.haskellProjects.default.outputs.apps or { }) // {
             hlint = {
               type = "app";

--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,8 @@
               ];
             };
 
-          # # packages are auto-wired via haskell-flake
-          # packages = config.haskellProjects.default.outputs.packages;
+          # packages are auto-wired via haskell-flake
+          packages = config.haskellProjects.default.outputs.packages;
 
           checks = config.haskellProjects.default.outputs.checks;
           apps = (config.haskellProjects.default.outputs.apps or {}) // {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,pypy3
+envlist = py39,py310,py311,py312,py313,pypy39,pypy310
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312,py313,pypy39,pypy310
+envlist = py39,py310,py311,py312,py313,py314,pypy39,pypy310
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
#139 describes the motivation.  Here's a quick summary of changes:

- Replaces hs-flake-utils with haskell-flake and flake-parts. The latter ones appear to be more actively maintained.
- Adds some Python versions so that we can use `nix develop` and then run `tox` against them.
- Adds a workflow that validates `flake.nix`, builds the Python/Haskell packages using `nix build`.
- The workflow will use the Cachix cache at https://app.cachix.org/cache/tahoe-lafs-zfec.